### PR TITLE
Update workflow and README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,21 +27,28 @@ jobs:
       - name: Build extension
         run: node build.js
 
-      - name: Zip browser builds (only for release)
+      - name: Set environment variables
+        if: github.event_name == 'release'
+        run: |
+          echo "REPO_NAME=$(basename ${{ github.repository }})" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+
+      - name: Zip and rename browser builds (only for release)
         if: github.event_name == 'release'
         run: |
           cd distro
           zip -r chrome.zip chrome/
           zip -r firefox.zip firefox/
-          mkdir -p ../packaged
-          mv chrome.zip firefox.zip ../packaged/
+          cd ..
+          mkdir -p packaged
+          mv distro/chrome.zip "packaged/${REPO_NAME}-chrome.${RELEASE_TAG}.zip"
+          mv distro/firefox.zip "packaged/${REPO_NAME}-firefox.${RELEASE_TAG}.zip"
 
       - name: Upload zips to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            packaged/chrome.zip
-            packaged/firefox.zip
+            packaged/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ This script:
 
 ---
 
+
 ### Load the Extension
+
+#### Option 1: From Source
 
 **Chrome**:
 
@@ -62,3 +65,19 @@ This script:
 2. Click **This Firefox**
 3. Click **Load Temporary Add-on**
 4. Select the `distro/firefox/manifest.json` file
+
+---
+
+#### Option 2: From Prebuilt ZIP (Recommended for Testing)
+
+You can also download prebuilt versions from the [latest GitHub Release](https://github.com/jacobtender/marian-extension/releases/latest). Look for files named:
+
+- `<repo>-chrome<version>.zip`
+- `<repo>-firefox<version>.zip`
+
+**Steps**:
+
+1. Download and extract the `.zip` file for your browser.
+2. Follow the same steps as **Option 1**, but select the extracted folder instead of `distro/`.
+
+> ⚠️ Extensions loaded this way are not auto-updated. You will need to repeat the steps for future versions.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ This script:
 
 ---
 
-
 ### Load the Extension
 
 #### Option 1: From Source
+
+> ⚠️ Extensions loaded this way are not auto-updated. You will need to repeat the steps for future versions.
+>
+> ⚠️ **Disclaimer:** Unpacked Chrome extensions loaded via "Developer Mode" will remain active across browser restarts, but Chrome may display a warning banner each time. These extensions are intended for development and testing purposes only.  
+>
+> In Firefox, temporary add-ons loaded through `about:debugging` will be deactivated when the browser is closed. To persist an extension in Firefox, it must be signed and installed as a `.xpi` file which is not yet available.
+>
 
 **Chrome**:
 
@@ -72,12 +78,10 @@ This script:
 
 You can also download prebuilt versions from the [latest GitHub Release](https://github.com/jacobtender/marian-extension/releases/latest). Look for files named:
 
-- `<repo>-chrome<version>.zip`
-- `<repo>-firefox<version>.zip`
+* `<repo>-chrome.<version>.zip`
+* `<repo>-firefox.<version>.zip`
 
 **Steps**:
 
 1. Download and extract the `.zip` file for your browser.
 2. Follow the same steps as **Option 1**, but select the extracted folder instead of `distro/`.
-
-> ⚠️ Extensions loaded this way are not auto-updated. You will need to repeat the steps for future versions.


### PR DESCRIPTION
- Workflow now adds saves the zip builds as `<repoName>-<browserName>.<realeaseTag>.zip`. 
- Added instructions to the README on how to install from the releases, and included note about firefox not being persistent.