### PR TITLE
remove top-level chrome/firefox dir from release zips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm ci
 
       - name: Build extension
-        run: node build.js
+        run: npm run build
 
       - name: Set environment variables
         if: github.event_name == 'release'
@@ -37,8 +37,8 @@ jobs:
         if: github.event_name == 'release'
         run: |
           cd distro
-          zip -r chrome.zip chrome/
-          zip -r firefox.zip firefox/
+          (cd chrome && zip -r ../chrome.zip .)
+          (cd firefox && zip -r ../firefox.zip .)
           cd ..
           mkdir -p packaged
           mv distro/chrome.zip "packaged/${REPO_NAME}-chrome.${RELEASE_TAG}.zip"

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "hardcover-librarian",
-  "version": "1.0.0",
-  "description": "",
+  "name": "marian-extension",
+  "version": "1.2.0",
+  "description": "Extracts book details from Amazon product pages. Created for the fine librarian corps of Hardcover.app.",
   "main": "background.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "node build.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jacobtender/hardcover-librarian.git"
+    "url": "git+https://github.com/jacobtender/marian-extension.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/jacobtender/hardcover-librarian/issues"
+    "url": "https://github.com/jacobtender/marian-extension/issues"
   },
-  "homepage": "https://github.com/jacobtender/hardcover-librarian#readme",
+  "homepage": "https://github.com/jacobtender/marian-extension#readme",
   "devDependencies": {
     "esbuild": "^0.25.8"
   }


### PR DESCRIPTION
Added `node build.js` to a npm script to put things in one place and fixed the release bundling so that it doesn't include the top-level target folder (currently the zips are classed as invalid plugins due to that)

Also fixed some of the information in package.json (added the description from manifest.json too)