### PR TITLE
fix manifest.json version including 'v' prefix

### DIFF
--- a/build.js
+++ b/build.js
@@ -26,7 +26,7 @@ function copyDir(src, dest) {
 function copyManifests(target) {
   const destDir = path.join(DIST_DIR, target);
   const baseManifest = JSON.parse(fs.readFileSync(path.join(SRC_DIR, "manifest.base.json")));
-  baseManifest.version = process.env.RELEASE_TAG || package.version;
+  baseManifest.version = process.env.RELEASE_TAG?.replace("v", "") || package.version;
   const targetManifest = JSON.parse(fs.readFileSync(path.join(SRC_DIR, `manifest.${target}.json`)));
 
   const combinedManifest = {


### PR DESCRIPTION
I neglected to check what format your tags are in!
Chrome complains that it's got an invalid version because it's injecting 'v1.2.1' - not '1.2.1'

This now strips off the 'v' so it should be valid