### PR TITLE
New extractor, source ID field, and revised image download logic

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,6 +1,7 @@
 import { getAmazonDetails } from './extractors/amazon.js';
 import { getGoodreadsDetails } from './extractors/goodreads.js';
 import { getStoryGraphDetails } from './extractors/storygraph.js';
+import { getGoogleBooksDetails } from './extractors/googlebooks.js';
 
 
 async function getDetails() {
@@ -10,6 +11,7 @@ async function getDetails() {
   if (url.includes('goodreads.com')) return await getGoodreadsDetails();
   if (url.includes('thestorygraph.com')) return await getStoryGraphDetails();
   if (url.includes('isbnsearch.org')) return getIsbnSearchDetails();
+  if (url.includes('google.com')) return await getGoogleBooksDetails();
   return {};
 }
 

--- a/src/extractors/goodreads.js
+++ b/src/extractors/goodreads.js
@@ -1,4 +1,5 @@
 const includedLabels = [
+    'Source ID',
     'Contributors',
     'Publisher',
     'Publication date',
@@ -17,6 +18,9 @@ const includedLabels = [
 async function getGoodreadsDetails() {
     console.log('[👩🏻‍🏫 Marian] Extracting GoodReads details');
     const bookDetails = {};
+
+    const sourceId = getGoodreadsBookIdFromUrl(window.location.href);
+    if (sourceId) bookDetails["Source ID"] = sourceId;
 
     const imgEl = document.querySelector('.BookCover__image img');
     bookDetails["img"] = imgEl?.src ? getHighResImageUrl(imgEl.src) : null;
@@ -166,6 +170,15 @@ function extractSeriesInfo(bookDetails) {
       bookDetails['Series Place'] = seriesPlaceMatch[1];
     }
   });
+}
+
+/**
+ * Extracts the Goodreads book ID from a Goodreads book URL.
+ */
+function getGoodreadsBookIdFromUrl(url) {
+  const regex = /goodreads\.com\/book\/show\/(\d+)(?:[.\-/]|$)/i;
+  const match = url.match(regex);
+  return match ? match[1] : null;
 }
 
 

--- a/src/extractors/googlebooks.js
+++ b/src/extractors/googlebooks.js
@@ -1,0 +1,364 @@
+// googlebooks.js
+
+const includedLabels = [
+    'Source ID',
+    'Contributors',
+    'Publisher',
+    'Publication date',
+    'Language',
+    'Print length',
+    'ISBN-10',
+    'ISBN-13',
+    'ASIN',
+    'Series',
+    'Series Place',
+    'Pages',
+    'Edition Format'
+];
+
+async function getGoogleBooksDetails() {
+    console.log('[👩🏻‍🏫 Marian] Extracting Google Books details');
+    const bookDetails = {};
+    
+
+    // Store the source ID
+    const sourceId = getGoogleBooksIdFromUrl(window.location.href);
+    if (sourceId) bookDetails["Source ID"] = sourceId;
+
+    // Extract cover image using volume ID
+    bookDetails["img"] = getGoogleBooksCoverUrl(sourceId);
+
+    // Extract title
+    bookDetails["Title"] = getGoogleBookTitle();
+
+    // Extract ISBNs
+    const { isbn10, isbn13 } = extractIsbns();
+    if (isbn10) bookDetails['ISBN-10'] = isbn10;
+    if (isbn13) bookDetails['ISBN-13'] = isbn13;
+
+    // Extract publication date
+    const releaseDate = getGoogleBookReleaseDate();
+    if (releaseDate) bookDetails['Publication date'] = releaseDate;
+
+    // Extract publisher
+    const publisher = getGoogleBookPublisher();
+    if (publisher) bookDetails['Publisher'] = publisher;
+
+    // Extract language
+    const language = getGoogleBookLanguage();
+    if (language) bookDetails['Language'] = language;
+
+    // Extract page count
+    const pageCount = getGoogleBookPageCount();
+    if (pageCount) bookDetails['Pages'] = pageCount;
+
+    // Extract description
+    const description = getGoogleBookDescription();
+    if (description) bookDetails['Description'] = description;
+
+    // Extract reading format
+    const readingFormat = getGoogleBookReadingFormat();
+    if (readingFormat) {
+        bookDetails['Reading Format'] = readingFormat;
+        // Set edition format based on reading format
+        if (readingFormat === 'E-Book') {
+            bookDetails['Edition Format'] = 'Digital';
+        } else if (readingFormat === 'Audiobook') {
+            bookDetails['Edition Format'] = 'Audiobook';
+        } else {
+            bookDetails['Edition Format'] = 'Print';
+        }
+    }
+
+    // Extract authors and convert to contributors format
+    const authors = getGoogleBookAuthors();
+    if (authors.length > 0) {
+        bookDetails['Contributors'] = authors.map(name => ({
+            name: name,
+            roles: ['Author']
+        }));
+    }
+
+    console.log("[👩🏻‍🏫 Marian] Google Books extraction complete:", bookDetails);
+
+    return {
+        ...bookDetails,
+    };
+}
+
+/**
+ * Extracts the book title from the Google Books page.
+ * @returns {string} Title text or empty string if not found.
+ */
+function getGoogleBookTitle() {
+    try {
+        const titleEl = document.querySelector('div.zNLTKd[aria-level="1"][role="heading"]');
+        if (titleEl) {
+            return titleEl.textContent.trim();
+        }
+        return "";
+    } catch (error) {
+        console.error("Error extracting Google Book title:", error);
+        return "";
+    }
+}
+
+/**
+ * Extracts ISBN-10 and ISBN-13 from the details panel.
+ * @returns {{ isbn10: string|null, isbn13: string|null }}
+ */
+function extractIsbns() {
+    const containers = document.querySelectorAll("div.zloOqf.PZPZlf");
+
+    for (const container of containers) {
+        const label = container.querySelector(".w8qArf");
+        if (label?.textContent?.toLowerCase().startsWith("isbn")) {
+            const valueEl = container.querySelector(".LrzXr");
+            const isbnText = valueEl?.textContent?.trim();
+            if (isbnText) {
+                const parts = isbnText.split(",").map((s) => s.trim());
+                let isbn10 = null;
+                let isbn13 = null;
+
+                for (const part of parts) {
+                    if (part.length === 13) isbn13 = part;
+                    else if (part.length === 10) isbn10 = part;
+                }
+
+                return { isbn10, isbn13 };
+            }
+        }
+    }
+
+    return { isbn10: null, isbn13: null };
+}
+
+/**
+ * Extracts the published date from the page.
+ * @returns {string}
+ */
+function getGoogleBookReleaseDate() {
+    try {
+        const allDetailBlocks = Array.from(document.querySelectorAll("div.zloOqf.PZPZlf"));
+
+        for (const block of allDetailBlocks) {
+            const labelSpan = block.querySelector("span.w8qArf");
+            if (labelSpan && labelSpan.textContent.trim().startsWith("Published")) {
+                const valueSpan = block.querySelector("span.LrzXr.kno-fv.wHYlTd.z8gr9e");
+                if (valueSpan) {
+                    return valueSpan.textContent.trim();
+                }
+            }
+        }
+
+        return "";
+    } catch (error) {
+        console.error("Error extracting published date:", error);
+        return "";
+    }
+}
+
+/**
+ * Extracts the publisher name from the details section.
+ * @returns {string}
+ */
+function getGoogleBookPublisher() {
+    try {
+        const allDetailBlocks = Array.from(document.querySelectorAll("div.zloOqf.PZPZlf"));
+
+        for (const block of allDetailBlocks) {
+            const labelSpan = block.querySelector("span.w8qArf");
+            if (labelSpan && labelSpan.textContent.trim().startsWith("Publisher")) {
+                const valueSpan = block.querySelector("span.LrzXr.kno-fv.wHYlTd.z8gr9e");
+                if (valueSpan) {
+                    const anchor = valueSpan.querySelector("a.fl");
+                    return (anchor?.textContent || valueSpan.textContent).trim();
+                }
+            }
+        }
+
+        return "";
+    } catch (error) {
+        console.error("Error extracting publisher:", error);
+        return "";
+    }
+}
+
+/**
+ * Extracts the release language from the info panel.
+ * @returns {string|null}
+ */
+function getGoogleBookLanguage() {
+    try {
+        const labelNodes = Array.from(document.querySelectorAll("div.zloOqf.PZPZlf"));
+
+        for (const node of labelNodes) {
+            const label = node.querySelector("span.w8qArf")?.textContent?.trim();
+            if (label?.startsWith("Language")) {
+                const value = node.querySelector("span.LrzXr, span.LrzXr a")?.textContent?.trim();
+                return value || null;
+            }
+        }
+
+        return null;
+    } catch (err) {
+        console.error("Failed to extract language", err);
+        return null;
+    }
+}
+
+/**
+ * Extracts and parses page count as a number.
+ * @returns {number|null}
+ */
+function getGoogleBookPageCount() {
+    try {
+        const labelNodes = Array.from(document.querySelectorAll("div.zloOqf.PZPZlf"));
+
+        for (const node of labelNodes) {
+            const label = node.querySelector("span.w8qArf")?.textContent?.trim();
+            if (label?.startsWith("Page count")) {
+                const valueText = node.querySelector("span.LrzXr")?.textContent?.trim();
+                const pageCount = valueText ? parseInt(valueText.replace(/[^\d]/g, ""), 10) : null;
+
+                if (!isNaN(pageCount)) {
+                    return pageCount;
+                }
+                return null;
+            }
+        }
+
+        return null;
+    } catch (err) {
+        console.error("Failed to extract page count", err);
+        return null;
+    }
+}
+
+/**
+ * Extracts the full description text.
+ * @returns {string}
+ */
+function getGoogleBookDescription() {
+    try {
+        const descriptionContainer = document.querySelector("div.Y0Qrof");
+        if (!descriptionContainer) {
+            return "";
+        }
+
+        // Simple text extraction - you can enhance this if needed
+        return descriptionContainer.textContent?.trim() || "";
+    } catch (err) {
+        console.error("Error while extracting book description", err);
+        return "";
+    }
+}
+
+/**
+ * Normalizes raw format string to one of: Audiobook, E-Book, or Physical Book.
+ * @param {string} rawFormat
+ * @returns {string}
+ */
+function normalizeReadingFormat(rawFormat) {
+    const format = rawFormat.toLowerCase();
+
+    if (format.includes("audio")) return "Audiobook";
+    if (format.includes("ebook") || format.includes("e-book") || format.includes("digital")) {
+        return "Ebook";  // Match your extension's format
+    }
+    if (format.includes("physical") || format.includes("hardcover") || 
+        format.includes("paperback") || format.includes("book")) {
+        return "Physical Book";
+    }
+
+    return "Physical Book"; // Fallback
+}
+
+/**
+ * Extracts and normalizes reading format from the details section.
+ * @returns {string}
+ */
+function getGoogleBookReadingFormat() {
+    try {
+        const formatContainer = [...document.querySelectorAll("div.zloOqf.PZPZlf")]
+            .find((div) => div.querySelector("span.w8qArf")?.textContent.includes("Format"));
+
+        if (!formatContainer) {
+            return "";
+        }
+
+        const formatValueEl = formatContainer.querySelector("span.LrzXr.kno-fv.wHYlTd.z8gr9e");
+        if (!formatValueEl) {
+            return "";
+        }
+
+        const rawFormat = formatValueEl.textContent.trim();
+        return normalizeReadingFormat(rawFormat);
+    } catch (error) {
+        console.error("Error extracting reading format:", error);
+        return "";
+    }
+}
+
+/**
+ * Extracts author names from the Google Books info panel.
+ * @returns {string[]} Array of author names.
+ */
+function getGoogleBookAuthors() {
+    try {
+        const authorContainer = Array.from(document.querySelectorAll("div.zloOqf.PZPZlf"))
+            .find((div) => div.textContent.trim().toLowerCase().startsWith("author"));
+
+        if (!authorContainer) {
+            return [];
+        }
+
+        const anchorElements = authorContainer.querySelectorAll("a.fl");
+        return Array.from(anchorElements).map((a) => a.textContent.trim());
+    } catch (err) {
+        console.error("Error while extracting book authors", err);
+        return [];
+    }
+}
+
+/**
+ * Extracts the Google Books volume ID from a given URL.
+ * @param {string} url - The current page URL.
+ * @returns {string|null} - The extracted volume ID or null if not found.
+ */
+function getGoogleBooksIdFromUrl(url) {
+    const patterns = [
+        /books\/edition\/(?:[^/]+\/)?([A-Za-z0-9_-]{10,})/, // e.g., books/edition/_/PYsFzwEACAAJ
+        /books\?id=([A-Za-z0-9_-]{10,})/, // e.g., books?id=PYsFzwEACAAJ
+        /\/volume\/([A-Za-z0-9_-]{10,})/, // e.g., volume/PYsFzwEACAAJ
+    ];
+
+    for (const pattern of patterns) {
+        const match = url.match(pattern);
+        if (match) return match[1];
+    }
+
+    return null;
+}
+
+/**
+ * Constructs a Google Books cover image URL with maximum resolution.
+ * @param {string} volumeId - The Google Books volume ID.
+ * @returns {string} - The full URL to the highest-resolution cover image.
+ */
+function getGoogleBooksCoverUrl(volumeId) {
+    if (!volumeId) return null;
+
+    const baseUrl = `https://books.google.com/books/publisher/content/images/frontcover/${volumeId}`;
+    const params = new URLSearchParams({
+        fife: "w1600-h2400", // High-resolution
+    });
+
+    return `${baseUrl}?${params.toString()}`;
+}
+
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export { getGoogleBooksDetails };

--- a/src/extractors/googlebooks.js
+++ b/src/extractors/googlebooks.js
@@ -1,23 +1,8 @@
 // googlebooks.js
-
-const includedLabels = [
-    'Source ID',
-    'Contributors',
-    'Publisher',
-    'Publication date',
-    'Language',
-    'Print length',
-    'ISBN-10',
-    'ISBN-13',
-    'ASIN',
-    'Series',
-    'Series Place',
-    'Pages',
-    'Edition Format'
-];
+import { getImageScore, logMarian, delay } from '../shared/utils.js';
 
 async function getGoogleBooksDetails() {
-    console.log('[👩🏻‍🏫 Marian] Extracting Google Books details');
+    logMarian('Extracting Google Books details');
     const bookDetails = {};
     
 
@@ -27,6 +12,7 @@ async function getGoogleBooksDetails() {
 
     // Extract cover image using volume ID
     bookDetails["img"] = getGoogleBooksCoverUrl(sourceId);
+    bookDetails["imgScore"] = bookDetails["img"] ? await getImageScore(bookDetails["img"]) : 0;
 
     // Extract title
     bookDetails["Title"] = getGoogleBookTitle();
@@ -79,7 +65,7 @@ async function getGoogleBooksDetails() {
         }));
     }
 
-    console.log("[👩🏻‍🏫 Marian] Google Books extraction complete:", bookDetails);
+    logMarian("Google Books extraction complete:", bookDetails);
 
     return {
         ...bookDetails,
@@ -355,10 +341,6 @@ function getGoogleBooksCoverUrl(volumeId) {
     });
 
     return `${baseUrl}?${params.toString()}`;
-}
-
-function delay(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 export { getGoogleBooksDetails };

--- a/src/extractors/storygraph.js
+++ b/src/extractors/storygraph.js
@@ -22,6 +22,10 @@ async function getStoryGraphDetails() {
     const imgEl = document.querySelector('.book-cover img');
     bookDetails["img"] = imgEl?.src ? getHighResImageUrl(imgEl.src) : null;
 
+    // Source ID
+    const sourceId = getStoryGraphBookIdFromUrl(window.location.href);
+    if (sourceId) bookDetails["Source ID"] = sourceId;
+
     // Book title
     const h3 = document.querySelector('.book-title-author-and-series h3');
     const rawTitle = h3?.childNodes[0]?.textContent.trim();
@@ -161,6 +165,16 @@ function getHighResImageUrl(src) {
 
 function delay(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
+    
+}
+
+/**
+ * Extracts the StoryGraph book ID from a StoryGraph book URL.
+ */
+function getStoryGraphBookIdFromUrl(url) {
+  const regex = /thestorygraph\.com\/books\/([^/?]+)/i;
+  const match = url.match(regex);
+  return match ? match[1] : null;
 }
 
 export { getStoryGraphDetails };

--- a/src/manifest.base.json
+++ b/src/manifest.base.json
@@ -42,7 +42,9 @@
 				"https://www.amazon.com/*dp/*",
 				"https://www.amazon.com/gp/product/*",
 				"https://www.goodreads.com/book/show/*",
-				"https://app.thestorygraph.com/books/*"
+				"https://app.thestorygraph.com/books/*",
+				"https://www.google.com/books/*"
+
 			],
 			"js": [
 				"dist/content.js"

--- a/src/popup.js
+++ b/src/popup.js
@@ -100,11 +100,6 @@ function renderDetails(details) {
         Date.now();
       downloadImage(details.img, fallbackId);
     });
-
-    img.addEventListener('click', () => {
-      const fallbackId = details['ISBN-13'] || details['ISBN-10'] || details['ASIN'] || details['Source ID'] || details['Title'] || Date.now();
-       downloadImage(details.img, fallbackId);
-    });
     sideBySideWrapper.appendChild(img);
 
     const textWrapper = document.createElement('div');

--- a/src/popup.js
+++ b/src/popup.js
@@ -155,6 +155,7 @@ function renderDetails(details) {
   container.appendChild(hr);
 
   const orderedKeys = [
+    'Source ID',
     'Series',
     'Series Place',
     'ISBN-13',

--- a/src/popup.js
+++ b/src/popup.js
@@ -49,7 +49,7 @@ function downloadFile(filename, content, type) {
   URL.revokeObjectURL(url);
 }
 
-function downloadImage(url, isbn13) {
+function downloadImage(url, bookId) {
   const highResUrl = url.replace(/\._[^.]+(?=\.)/, '');
   fetch(highResUrl)
     .then(res => res.blob())
@@ -58,8 +58,8 @@ function downloadImage(url, isbn13) {
       const a = document.createElement('a');
       a.href = blobUrl;
       // Clean the ISBN to avoid problematic chars in filename
-      const safeIsbn = isbn13.replace(/[^a-z0-9]/gi, '');
-      a.download = `${safeIsbn}_cover.jpg`;
+      const safeId = bookId.replace(/[^a-z0-9]/gi, '');
+      a.download = `${safeId}_cover.jpg`;
       document.body.appendChild(a);
       a.click();
       a.remove();
@@ -90,7 +90,10 @@ function renderDetails(details) {
     img.title = 'Click to download';
     img.style.maxWidth = '100px';
     img.style.cursor = 'pointer';
-    img.addEventListener('click', () => downloadImage(details.img, details['ISBN-13']));
+    img.addEventListener('click', () => {
+      const fallbackId = details['ISBN-13'] || details['ISBN-10'] || details['ASIN'] || details['Source ID'];
+       downloadImage(details.img, fallbackId);
+    });
     sideBySideWrapper.appendChild(img);
 
     const textWrapper = document.createElement('div');

--- a/src/popup.js
+++ b/src/popup.js
@@ -91,7 +91,18 @@ function renderDetails(details) {
     img.style.maxWidth = '100px';
     img.style.cursor = 'pointer';
     img.addEventListener('click', () => {
-      const fallbackId = details['ISBN-13'] || details['ISBN-10'] || details['ASIN'] || details['Source ID'];
+      const fallbackId =
+        details['ISBN-13'] ||
+        details['ISBN-10'] ||
+        details['ASIN'] ||
+        details['Source ID'] ||
+        details['Title'] ||
+        Date.now();
+      downloadImage(details.img, fallbackId);
+    });
+
+    img.addEventListener('click', () => {
+      const fallbackId = details['ISBN-13'] || details['ISBN-10'] || details['ASIN'] || details['Source ID'] || details['Title'] || Date.now();
        downloadImage(details.img, fallbackId);
     });
     sideBySideWrapper.appendChild(img);

--- a/src/popup.js
+++ b/src/popup.js
@@ -204,12 +204,12 @@ function renderDetails(details) {
   container.appendChild(hr);
 
   const orderedKeys = [
-    'Source ID',
     'Series',
     'Series Place',
     'ISBN-13',
     'ISBN-10',
     'ASIN',
+    'Source ID',
     // 'Author',
     // 'Narrator',
     'Contributors',

--- a/src/popup.js
+++ b/src/popup.js
@@ -203,6 +203,7 @@ function renderDetails(details) {
   const hr = document.createElement('hr');
   container.appendChild(hr);
 
+  // Render details in a way that reflects the order of a Hardcover Edition edit form
   const orderedKeys = [
     'Series',
     'Series Place',
@@ -210,8 +211,6 @@ function renderDetails(details) {
     'ISBN-10',
     'ASIN',
     'Source ID',
-    // 'Author',
-    // 'Narrator',
     'Contributors',
     'Publisher',
     'Reading Format',
@@ -221,8 +220,8 @@ function renderDetails(details) {
     'Publication date',
     'Language'
   ];
-  const rendered = new Set();
 
+  const rendered = new Set();
   orderedKeys.forEach(key => {
     if (key in details) {
       renderRow(container, key, details[key]);
@@ -230,9 +229,18 @@ function renderDetails(details) {
     }
   });
 
+  // Filter out keys that shouldn't be rendered in the generic loop
+  const filteredKeys = [
+    'img',
+    'imgScore',
+    'Title',
+    'Description',
+  ];
+
+  // Render remaining keys that weren't in the ordered list
   Object.entries(details).forEach(([key, value]) => {
-    if (key === 'img' || key === 'Title' || key === 'Description' || rendered.has(key)) return;
-        renderRow(container, key, value);
+    if (filteredKeys.includes(key) || rendered.has(key)) return;
+    renderRow(container, key, value);
   });
 }
 

--- a/src/shared/allowed-patterns.js
+++ b/src/shared/allowed-patterns.js
@@ -3,7 +3,8 @@ const ALLOWED_PATTERNS = [
   /https:\/\/www\.amazon\.com\/gp\/product\/[A-Z0-9]{10}/,
   /https:\/\/www\.amazon\.com\/[^/]+\/dp\/[A-Z0-9]{10}/,
   /https:\/\/www\.goodreads\.com\/book\/show\/\d+(-[a-zA-Z0-9-]+)?/,
-  /^https:\/\/app\.thestorygraph\.com\/books\/[0-9a-fA-F-]+$/
+  /^https:\/\/app\.thestorygraph\.com\/books\/[0-9a-fA-F-]+$/,
+  /^https?:\/\/(www\.)?google\.[a-z.]+\/books/
 ];
 
 function isAllowedUrl(url) {


### PR DESCRIPTION
Resubmission due to old branch being pushed. Adding support for the new google books page (`https://google.com/books/*`). Some covers are fairly low-resolution, but I attempted to get the highest res available with `<url>?fife=w1600-h2400`.

>Note, TLD (ca/com/etc) can be agnostic, however as your current extension only supports `.com` I am leaving it as-is.

Firefox
<img width="2794" height="1140" alt="Screenshot from 2025-08-05 23-39-10" src="https://github.com/user-attachments/assets/082ab7d4-388b-4e65-9275-0f46362679bd" />
<img width="2794" height="1140" alt="Screenshot from 2025-08-05 23-39-18" src="https://github.com/user-attachments/assets/39b9e58f-9009-4670-925c-ec1a19fa81b5" />
<img width="2794" height="1140" alt="Screenshot from 2025-08-05 23-41-18" src="https://github.com/user-attachments/assets/bdc828d1-5621-4a06-a588-8e1fbf12a187" />

Chrome
<img width="2794" height="1140" alt="Screenshot from 2025-08-05 23-42-07" src="https://github.com/user-attachments/assets/41873a06-e86d-4f6f-9882-3ebae79c8648" />
<img width="2794" height="1140" alt="Screenshot from 2025-08-05 23-42-19" src="https://github.com/user-attachments/assets/c134963b-b287-48f8-b361-fa5132d8d706" />
<img width="2794" height="1140" alt="Screenshot from 2025-08-05 23-42-31" src="https://github.com/user-attachments/assets/6efac21e-fa77-4381-b7f7-ccbfb97556c7" />
