### PR TITLE
Better reload handling and unsupported page reporting

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -113,7 +113,8 @@
       border-top: 2px solid #384151;
     }
 
-    #hardcover-callout {
+    #hardcover-callout, 
+    .callout {
       display: flex;
       align-items: center;
       gap: 10px;
@@ -167,8 +168,8 @@
 
 <body>
   <div id="content">
-    <div id="loading" style="display: none;">Loading details...</div>
-    <div id="error" style="display: none; color: red;"></div>
+    <div id="loading" class="callout" style="display: none;">Loading details...</div>
+    <div id="error" class="callout" style="display: none;"></div>
     <div id="details"></div>
   </div>
   <!-- <div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -16,6 +16,10 @@
       color: white;
       padding: 0;                  /* move padding to #content */
     }
+    a {
+      color: white;
+      text-decoration: underline;
+    }
 
     img {
       max-width: 100%;

--- a/src/popup.html
+++ b/src/popup.html
@@ -168,8 +168,7 @@
 
 <body>
   <div id="content">
-    <div id="loading" class="callout" style="display: none;">Loading details...</div>
-    <div id="error" class="callout" style="display: none;"></div>
+    <div id="status" class="callout" style="display: none;">Loading details...</div>
     <div id="details"></div>
   </div>
   <!-- <div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,6 +1,6 @@
 import { isAllowedUrl } from "./shared/allowed-patterns";
 
-const DEBUG = true;
+const DEBUG = false;
 
 const statusEl = document.getElementById('status');
 const detailsEl = document.getElementById('details');

--- a/src/popup.js
+++ b/src/popup.js
@@ -347,7 +347,7 @@ function buildIssueUrl(tabUrl) {
   const domain = new URL(tabUrl).hostname.replace(/^www\./, '');
   const title = `Unsupported URL detected on ${domain}`;
   const body = [
-    'This page is not currently supported by the Marian extension:',
+    'This page is not currently supported by Marian:',
     '',
     tabUrl, // <-- raw URL here; we encode the whole body once
     '',
@@ -440,14 +440,14 @@ function tryGetDetails(retries = 8, delay = 300) {
               // reload the TAB once, then retry after it finishes loading
               if (!didRefresh) {
                 didRefresh = true;
-                showStatus("Content script not ready, refreshing tab...");
+                // showStatus("Content script not ready, refreshing tab...");
                 chrome.tabs.reload(tab.id, { bypassCache: true });
-                showStatus("Tab reloaded, waiting for content script...");
+                showStatus("Tab reloaded, fetching details...");
 
                 const onUpdated = (updatedTabId, info) => {
                   if (updatedTabId === tab.id && info.status === 'complete') {
                     chrome.tabs.onUpdated.removeListener(onUpdated);
-                    console.log(retries, 'Tab reloaded, retrying to get details...');
+                    console.log(retries, 'Tab reloaded, fetching details again...');
                     setTimeout(() => attempt(retries), 350); // retry fresh after reload
                   }
                 };


### PR DESCRIPTION
<img width="1326" height="554" alt="image" src="https://github.com/user-attachments/assets/25df87e8-1ff4-4d0c-a089-95870c291d18" />

Fixes an infinite reload case on an unsupported page on a supported site. It tries once and then stops. If it details can't be fetched, it's probably just missing from the manifest's list of supported URLs.

In this case, we now show a status with a link to a pre-filled issue requesting support.