### PR TITLE
Fix Marian icon in firefox sidebar

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -11,6 +11,9 @@
 		}
 	},
 	"sidebar_action": {
+		"default_icon": {
+			"128": "icons/icon.png"
+		},
 		"default_title": "Marian",
 		"default_panel": "popup.html"
 	},


### PR DESCRIPTION
fix the Marian icon showing up as a puzzle piece in the Firefox sidebar