### PR TITLE
Fix amazon info  on non .com sites

### DIFF
--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -33,6 +33,8 @@ async function getAmazonDetails() {
 
   if (bookDetails["Edition Format"]?.includes("Kindle")) {
     bookDetails['Reading Format'] = 'Ebook';
+    // Normalize `Kindle Edition` to to `Kindle` like it is on amazon.com 
+    bookDetails["Edition Format"] = "Kindle";
   } else if (
     bookDetails["Edition Format"]?.toLowerCase().includes("audio") ||
     bookDetails["Edition Format"]?.toLowerCase().includes("audible") ||
@@ -219,11 +221,7 @@ function getBookDescription() {
 function getSelectedFormat() {
   const selected = document.querySelector('#tmmSwatches .swatchElement.selected .slot-title span[aria-label]');
   if (selected) {
-    let text = selected.getAttribute('aria-label')?.replace(' Format:', '').trim();
-    if (text.startsWith("Kindle") && text !== "Kindle") {
-      text = "Kindle";
-    }
-    return text;
+    return selected.getAttribute('aria-label')?.replace(' Format:', '').trim();
   }
   return null;
 }


### PR DESCRIPTION
I noticed for some amazon domains like [amazon.ca](https://www.amazon.ca/Bunny-Girl-Evolution-Monster-LitRPG-ebook/dp/B0FJ6QRBBW) it will say `Kindle Edition` instead of just `Kindle`, this breaks the check that sets the type to Ebook.

I also fixed it if the publisher is in the format of `Name; Edition (Date published)` example: [amazon.in](https://www.amazon.in/Beneath-Dragoneye-Moons-Phoenix-Peaks-ebook/dp/B0DT7SNDFZ)