### PR TITLE
Fix Amazon scraping waiting on image score calculaton

### DIFF
--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -67,8 +67,8 @@ async function getAmazonDetails() {
 
 async function getCover() {
   const imgEl = document.querySelector('#imgBlkFront, #landingImage');
-  /**@type{string|null}*/
-  const coverUrl = imgEl?.src ? getHighResImageUrl(imgEl.src) : null;
+  let coverUrl = imgEl?.dataset?.oldHires || imgEl?.src
+  coverUrl = coverUrl ? getHighResImageUrl(coverUrl) : null;
 
   return {
     img: coverUrl,

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -19,7 +19,7 @@ const includedLabels = new Set([
 async function getAmazonDetails() {
   logMarian('Extracting Amazon details');
 
-  const imgEl = document.querySelector('#imgBlkFront, #landingImage');
+  coverData = getCover()
   const bookDetails = getDetailBullets();
   const audibleDetails = getAudibleDetails();
   const contributors = extractAmazonContributors();
@@ -27,8 +27,6 @@ async function getAmazonDetails() {
   bookDetails["Edition Format"] = getSelectedFormat() || '';
   bookDetails["Title"] = document.querySelector('#productTitle')?.innerText.trim();
   bookDetails["Description"] = getBookDescription() || '';
-  bookDetails["img"] = imgEl?.src ? getHighResImageUrl(imgEl.src) : null;
-  bookDetails["imgScore"] = imgEl?.src ? await getImageScore(imgEl.src) : 0;
   bookDetails["Contributors"] = contributors;
   
   if (bookDetails["Edition Format"]?.includes("Kindle")) {
@@ -58,12 +56,24 @@ async function getAmazonDetails() {
   const mergedDetails = {
     ...bookDetails,
     ...audibleDetails,
+    ...(await coverData)
   };
 
   delete mergedDetails.Edition;
   delete mergedDetails.Version;
 
   return mergedDetails;
+}
+
+async function getCover() {
+  const imgEl = document.querySelector('#imgBlkFront, #landingImage');
+  /**@type{string|null}*/
+  const coverUrl = imgEl?.src ? getHighResImageUrl(imgEl.src) : null;
+
+  return {
+    img: coverUrl,
+    imgScore: coverUrl ? await getImageScore(coverUrl) : 0
+  }
 }
 
 function getHighResImageUrl(src) {


### PR DESCRIPTION
Removed the blocking await for calculating the image score that was preventing the rest of the scrape from happening in the meantime.

this fixes some edge cases when you click load on an page and immediately switch to another tab while its still calculating the image score it doesn't load the correct information.
this possibly also fixes the issue where the `getHighResImageUrl` function fails to get the original url and you get a low res cover image instead by preferring to use the higher res image used in the popup as a base, it is normally 1500px tall (or square for audiobooks). but I haven't been able to reproduce the issue consistently