### PR TITLE
Fix permision error when trying to download image

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -7,6 +7,7 @@
 		"default_path": "popup.html"
 	},
 	"permissions": [
+		"downloads",
 		"activeTab",
 		"tabs",
 		"sidePanel",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -18,6 +18,7 @@
 		"default_panel": "popup.html"
 	},
 	"permissions": [
+		"downloads",
 		"storage",
 		"scripting",
 		"activeTab",

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -28,20 +28,22 @@ function formatDate(dateStr) {
 }
 
 function downloadImage(url, bookId) {
-  fetch(url)
-    .then(res => res.blob())
-    .then(blob => {
-      const blobUrl = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = blobUrl;
-      const safeId = String(bookId || '').replace(/[^a-z0-9]/gi, '');
-      a.download = `${safeId}_cover.jpg`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(blobUrl);
-    })
-    .catch(err => console.error('Image download failed:', err));
+  const safeId = String(bookId || '').replace(/[^a-z0-9]/gi, '');
+  const filename = `${safeId}_cover.jpg`;
+
+  chrome.downloads.download({
+    url: url,
+    filename: filename,
+    saveAs: false,
+    conflictAction: 'uniquify'
+  }, (downloadId) => {
+    if (chrome.runtime.lastError) {
+      console.error('Image download failed:', chrome.runtime.lastError);
+      showStatus(`Download failed: ${chrome.runtime.lastError.message}`);
+    } else {
+      console.log('Image download started, ID:', downloadId);
+    }
+  });
 }
 
 


### PR DESCRIPTION
Use chrome.downloads api to download the image instead of calling fetch, this makes it so that the extension does not need cors access to every image CDN domain

~~TODO: remove unneeded CDN domains~~

fixes #90