### PR TITLE
feat: add penguinrandomhouse.com extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Book pages on these sites are currently supported by Marian. To request support 
 - Bookshop.org
 - Romance.io
 - IndieBookstores.ca
+- Penguin Random House
 
 ## Creating an extractor
 

--- a/src/extractors/index.js
+++ b/src/extractors/index.js
@@ -17,6 +17,7 @@ import { koboScraper } from "./kobo";
 import { libbyScraper, overdriveScraper, teachingbooksScraper } from "./overdrive";
 import { librofmScraper } from "./librofm";
 import { openlibraryScraper } from "./openlibrary";
+import { penguinRandomHouseScraper } from "./penguinrandomhouse";
 import { romanceIoScraper } from "./romanceio";
 import { storygraphScraper } from "./storygraph";
 
@@ -39,6 +40,7 @@ const extractors = [
   new librofmScraper(),
   new openlibraryScraper(),
   new overdriveScraper(),
+  new penguinRandomHouseScraper(),
   new romanceIoScraper(),
   new storygraphScraper(),
   new teachingbooksScraper(),

--- a/src/extractors/penguinrandomhouse.js
+++ b/src/extractors/penguinrandomhouse.js
@@ -1,0 +1,174 @@
+import {
+  addContributor,
+  collectObject,
+  getCoverData,
+  getFormattedText,
+  normalizeReadingFormat,
+} from "../shared/utils.js";
+import { Extractor } from "./AbstractExtractor.js";
+
+const REGEX_SERIES_PLACE = /\d+(?=\s+of)/;
+const REGEX_TIME_HOURS_MINUTES =
+  /(\d+)\s*Hours?\s*(?:,|and)?\s*(\d+)?\s*Minutes?/i;
+
+class penguinRandomHouseScraper extends Extractor {
+  get _name() {
+    return "penguinrandomhouse.com Extractor";
+  }
+  // Reloading resets reading format selection
+  needsReload = false;
+  _sitePatterns = [/https:\/\/(?:www\.)?penguinrandomhouse\.com\/books\/(\d+)/];
+
+  async getDetails() {
+    let details = {};
+    const coverData = getCoverData(document.querySelector("#coverFormat").src);
+
+    getProductDetails(details);
+
+    return collectObject([details, coverData]);
+  }
+}
+
+function getProductDetails(details) {
+  details["Title"] = document.querySelector("h1").textContent.trim();
+  details["Contributors"] = getContributors();
+  details["Description"] = getFormattedText(
+    document.querySelector("#book-description-copy")
+  );
+
+  const activeDropdownElement = document.querySelector(
+    ".panel-heading.selected button"
+  );
+  const mobileReadingFormat = document.querySelector(".frmt-text");
+
+  // Check if elements are visible, as they're still in the HTML
+  if (
+    activeDropdownElement?.offsetParent !== null &&
+    activeDropdownElement?.innerText
+  ) {
+    // Some pages use one type of dash and some use the other type
+    details["Reading Format"] = normalizeReadingFormat(
+      activeDropdownElement.innerText
+        .replace(/\n/, "")
+        .replace("–", "")
+        .replace("-", "")
+    );
+  } else if (mobileReadingFormat.offsetParent !== null) {
+    details["Reading Format"] = normalizeReadingFormat(
+      mobileReadingFormat.innerText
+    );
+  }
+
+  if (document.querySelector(".series span a")?.innerText) {
+    details["Series"] = document.querySelector(".series span a").innerText;
+    details["Series Place"] = REGEX_SERIES_PLACE.exec(
+      document.querySelector(".series span").textContent
+    );
+  }
+
+  const rawDetails = document.querySelector(
+    "#drawer-product-details .drawer-copy-text"
+  ).children;
+
+  for (let i = 0; i < rawDetails.length; i++) {
+    switch (rawDetails[i].childNodes[0].textContent) {
+      case "ISBN":
+        details["ISBN-13"] = rawDetails[i].childNodes[1].textContent;
+        break;
+      case "Published on":
+        details["Publication date"] = rawDetails[i].childNodes[1].textContent;
+        break;
+      case "Published by":
+        details["Publisher"] = rawDetails[i].childNodes[1].textContent;
+        break;
+      case "Pages":
+        details["Pages"] = rawDetails[i].childNodes[1].textContent;
+        break;
+      case "Length":
+        const timeMatch = rawDetails[i].childNodes[1].textContent.match(
+          REGEX_TIME_HOURS_MINUTES
+        );
+
+        const listeningLength = [];
+
+        if (timeMatch[1]) listeningLength.push(`${timeMatch[1]} hours`);
+        if (timeMatch[2]) listeningLength.push(`${timeMatch[2]} minutes`);
+
+        details["Listening Length"] = listeningLength;
+        break;
+    }
+  }
+}
+
+function getContributors() {
+  const rawContributors = document.querySelectorAll(".show .contributor");
+  const contributors = [];
+
+  for (let i = 0; i < rawContributors.length; i++) {
+    // The labels for authors are inconsistent across categories, however they're always first
+    if (i == 0) {
+      for (let j = 0; j < rawContributors[i].children.length; j++) {
+        addContributor(
+          contributors,
+          rawContributors[i].children[j].textContent,
+          "Author"
+        );
+      }
+    } else {
+      switch (
+        rawContributors[i].firstChild.textContent
+          .split(" ")
+          .slice(0, 2)
+          .join(" ")
+      ) {
+        case "Read by":
+          for (let j = 0; j < rawContributors[i].children.length; j++) {
+            addContributor(
+              contributors,
+              rawContributors[i].children[j].textContent,
+              "Narrator"
+            );
+          }
+          break;
+        case "Illustrated by" || "Artwork by":
+          for (let j = 0; j < rawContributors[i].children.length; j++) {
+            addContributor(
+              contributors,
+              rawContributors[i].children[j].textContent,
+              "Illustrator"
+            );
+          }
+          break;
+        case "Translated by":
+          for (let j = 0; j < rawContributors[i].children.length; j++) {
+            addContributor(
+              contributors,
+              rawContributors[i].children[j].textContent,
+              "Translator"
+            );
+          }
+          break;
+        case "Cover Design":
+          for (let j = 0; j < rawContributors[i].children.length; j++) {
+            addContributor(
+              contributors,
+              rawContributors[i].children[j].textContent,
+              "Cover Artist"
+            );
+          }
+          break;
+        default:
+          for (let j = 0; j < rawContributors[i].children.length; j++) {
+            addContributor(
+              contributors,
+              rawContributors[i].children[j].textContent
+            );
+          }
+      }
+    }
+  }
+
+  return contributors;
+}
+
+export { penguinRandomHouseScraper };

--- a/src/manifest.base.json
+++ b/src/manifest.base.json
@@ -110,7 +110,8 @@
 		"https://www.romance.io/books/*",
 		"https://www.barnesandnoble.com/*",
 		"https://www.indiebookstores.ca/book/*",
-		"https://openlibrary.org/*"
+		"https://openlibrary.org/*",
+		"https://www.penguinrandomhouse.com/books/*"
 	],
 	"icons": {
 		"16": "icons/icon.png",


### PR DESCRIPTION
- Retrieving the "Reading Format" key does rely on the user not closing the associated dropdown.  The information associated with that format is still pulled however.  When I checked the HTML there wasn't a reliable way to select the associated dropdown.
- The `REGEX_TIME_HOURS_MINUTES` regex was copied from the `storygraph.js` extractor.  I think it'd be good to move these to a util function in a future commit.  Which I plan to do if there's no objections.  It'd be useful for future extractors as well, since `x hours x minutes` is a common time format.
- I set the contributor roles based on what's currently supported in the Hardcover UI, which includes `Cover Artist`.