### PR TITLE
Fix: openlibrary bug where author does not have a type, only value

### DIFF
--- a/src/extractors/openlibrary.js
+++ b/src/extractors/openlibrary.js
@@ -171,7 +171,7 @@ async function getDetails(idUrl) {
         if (authorKey == undefined) {
           if (!("type" in author)) continue;
           const typeKey = author.type.key;
-          if (typeKey !== "/type/author_role") {
+          if (typeKey && typeKey !== "/type/author_role") {
             // TODO: get role name from endpoint
             role = typeKey.split("/").splice(-1)[0] || typeKey;
           }


### PR DESCRIPTION
if the author has no type then the extension failed to scrape on openlibrary

affected url
https://openlibrary.org/books/OL2847195M/LISP