### PR TITLE
FIX: google books missing information

### DIFF
--- a/src/extractors/googlebooks.js
+++ b/src/extractors/googlebooks.js
@@ -321,7 +321,7 @@ function getGoogleBookPageCount() {
 function getGoogleBookDescription() {
     try {
         // NOTE: this seems very fragile, if the class name changes then this breaks 
-        const descriptionContainer = queryDeep("g-expandable-content[data-eb='0'] div.Y0Qrof", KNOWN_HOSTS);
+        const descriptionContainer = queryDeep(`.T4Ew8c [jsname="AKKCW"] [data-eb="0"]`, KNOWN_HOSTS);
         if (!descriptionContainer) {
             return "";
         }


### PR DESCRIPTION
 The query selector I used for getting the authors gets all the labels and could be useful for improving the google books scraper until it is switched to use the API instead.
 That would probably be a better option since this scraper is very fragile, I also fixed the fetching of the description because google changed how that works (it's no longer a web component)