### PR TITLE
Make Audible and Amazon use the Audible and Audnexus apis when fetching audiobooks 

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -200,7 +200,7 @@ runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 
-  if (request.action === 'fetchDepositData') {
+  if (request.action === 'fetchUrl') {
     handleFetchRequest(request.url).then(sendResponse);
     return true;
   }

--- a/src/content.js
+++ b/src/content.js
@@ -24,7 +24,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         sendResponse(details);
       } catch (e) {
         logMarian("Error getting info", e);
-        sendResponse(null);
+        sendResponse({ __marian_error: e.message || String(e) });
       }
     };
 

--- a/src/extractors/README.md
+++ b/src/extractors/README.md
@@ -146,6 +146,8 @@ Takes in a list of objects, promises of objects or null/undefined.
 it will await all promises at the same time and then merge them into a single object,
 if a key is present in more than one object it will be overwritten, by order of the list.
 
+It will merge `Collections` and `Mappings`
+
 ### getCoverData
 
 Takes in a URL, or a list of URLs and returns an

--- a/src/extractors/README.md
+++ b/src/extractors/README.md
@@ -267,6 +267,24 @@ const title = queryDeep('h1', ['product-header']);
 Gets a DOM from a html request.
 If this is used in a scraper script, then it will only work for domains that the current page has CORS access to.
 
+### fetchBackground
+
+Performs an HTTP request via the background script to bypass CORS and Content-Security-Policy (CSP) restrictions.
+
+Takes in a `url` string to fetch.
+Returns a promise that resolves with the response text on success, or rejects with an error message on failure.
+
+Example:
+```javascript
+try {
+  const htmlString = await fetchBackground('https://example.com/data');
+  const tempDiv = document.createElement('div');
+  tempDiv.innerHTML = htmlString;
+} catch (err) {
+  console.error("Failed to fetch data:", err);
+}
+```
+
 ### runtime
 
 Exports the `browser.runtime` (Firefox) or `chrome.runtime` (Chrome) API,

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -1,5 +1,6 @@
+import { addContributor, cleanText, collectObject, fetchBackground, getCoverData, getFormattedText, logMarian, normalizeReadingFormat } from '../shared/utils.js';
 import { Extractor } from "./AbstractExtractor.js"
-import { logMarian, getFormattedText, getCoverData, addContributor, cleanText, normalizeReadingFormat, collectObject } from '../shared/utils.js';
+
 const bookSeriesRegex = /^Book (\d+) of \d+$/i;
 
 const includedLabels = new Set([
@@ -131,9 +132,9 @@ async function fetchAudnexusDetails(asin, audibleDetails) {
   }
 
   try {
-    const res = await fetch(`https://api.audnex.us/books/${asin}?region=${region}`);
-    if (res.ok) {
-      const data = await res.json();
+    const resHtml = await fetchBackground(`https://api.audnex.us/books/${asin}?region=${region}`);
+    if (resHtml) {
+      const data = JSON.parse(resHtml);
       const details = {};
       if (data.isbn) {
         details['ISBN-13'] = data.isbn;

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -1,5 +1,6 @@
 import { addContributor, cleanText, collectObject, fetchBackground, getCoverData, getFormattedText, logMarian, normalizeReadingFormat } from '../shared/utils.js';
 import { Extractor } from "./AbstractExtractor.js"
+import { getRegion, fetchAudnexusApiDetails, fetchAudibleApiDetails } from './audible.js';
 
 const bookSeriesRegex = /^Book (\d+) of \d+$/i;
 
@@ -83,18 +84,18 @@ class amazonScraper extends Extractor {
     }
 
     const audibleAsin = getAudibleAsin();
-    let audnexusPromise = undefined;
+    let apiPromise = {};
     if (audibleAsin && audibleAsin !== asin) {
       delete bookDetails["ASIN"];
       bookDetails["Amazon ASIN"] = asin;
       audibleDetails["ASIN"] = audibleAsin;
-      audnexusPromise = fetchAudnexusDetails(audibleAsin, audibleDetails);
+      apiPromise = fetchApiDetails(audibleAsin, audibleDetails);
     }
 
     const mergedDetails = await collectObject([
       bookDetails,
-      audnexusPromise,
       audibleDetails,
+      apiPromise, // overwriting contributor scraped data from amazon
       coverData,
     ]);
 
@@ -108,58 +109,18 @@ class amazonScraper extends Extractor {
   }
 }
 
-async function fetchAudnexusDetails(asin, audibleDetails) {
+async function fetchApiDetails(asin, audibleDetails) {
   if (!asin || audibleDetails['Reading Format'] !== 'Audiobook') {
     return {};
   }
 
-  const tld = audibleDetails['_detectedRegion'] || '';
-  let region = 'us';
-  if (tld === 'ca') region = 'ca';
-  else if (tld === 'co.uk' || tld === 'uk') region = 'uk';
-  else if (tld === 'com.au' || tld === 'au') region = 'au';
-  else if (tld === 'fr') region = 'fr';
-  else if (tld === 'de') region = 'de';
-  else if (tld === 'it') region = 'it';
-  else if (tld === 'es') region = 'es';
-  else if (tld === 'in') region = 'in';
-  else if (tld === 'co.jp' || tld === 'jp') region = 'jp';
-  else if (tld === 'com') region = 'us';
-  else {
-    // Fallback to host detection if no label found
-    if (window.location.host.includes('.ca')) region = 'ca';
-    else if (window.location.host.includes('.co.uk')) region = 'uk';
-    else if (window.location.host.includes('.com.au')) region = 'au';
-    else if (window.location.host.includes('.fr')) region = 'fr';
-    else if (window.location.host.includes('.de')) region = 'de';
-    else if (window.location.host.includes('.it')) region = 'it';
-    else if (window.location.host.includes('.es')) region = 'es';
-    else if (window.location.host.includes('.in')) region = 'in';
-    else if (window.location.host.includes('.co.jp')) region = 'jp';
-  }
+  let tld = audibleDetails['_detectedRegion'] || document.location.host.split("amazon").pop();
+  const region = getRegion(tld);
 
-  try {
-    const resHtml = await fetchBackground(`https://api.audnex.us/books/${asin}?region=${region}`);
-    if (resHtml) {
-      const data = JSON.parse(resHtml);
-      const details = {};
-      if (data.isbn) {
-        details['ISBN-13'] = data.isbn;
-      }
-      if (data.genres) {
-        details.Categories = data.genres.map(g => cleanText(g.name));
-      }
-      if (data.rating) {
-        details['Average Rating'] = parseFloat(data.rating);
-      }
-      logMarian("Fetched extra data from Audnexus for Amazon Audiobook", details);
-      return details;
-    }
-  } catch (e) {
-    logMarian("Failed to fetch Audnexus data for Amazon Audiobook", e);
-    if (e.message?.startsWith('MISSING_PERMISSION:')) throw e;
-  }
-  return {};
+  return await collectObject([
+    fetchAudibleApiDetails(asin, tld),
+    fetchAudnexusApiDetails(asin, region),
+  ])
 }
 
 async function getCover() {

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -68,7 +68,7 @@ class amazonScraper extends Extractor {
     // If the isbn10 is the isbn13 and is in the ASIN
     const isbn10 = bookDetails["ISBN-10"]?.replace("-", "");
     const isbn13 = bookDetails["ISBN-13"]?.replace("-", "");
-    const asin = bookDetails["ASIN"];
+    const asin = bookDetails["ASIN"] ?? audibleDetails["ASIN"];
     if (
       isbn10 != null &&
       isbn13 != null &&
@@ -81,19 +81,76 @@ class amazonScraper extends Extractor {
       bookDetails["ISBN-10"] = asin;
     }
 
+    const audnexusPromise = fetchAudnexusDetails(asin, audibleDetails);
+
     const mergedDetails = await collectObject([
       bookDetails,
+      audnexusPromise,
       audibleDetails,
       coverData,
     ]);
 
     delete mergedDetails.Edition;
     delete mergedDetails.Version;
+    delete mergedDetails._detectedRegion;
 
     // logMarian("details", mergedDetails);
 
     return mergedDetails;
   }
+}
+
+async function fetchAudnexusDetails(asin, audibleDetails) {
+  if (!asin || audibleDetails['Reading Format'] !== 'Audiobook') {
+    return {};
+  }
+
+  const tld = audibleDetails['_detectedRegion'] || '';
+  let region = 'us';
+  if (tld === 'ca') region = 'ca';
+  else if (tld === 'co.uk' || tld === 'uk') region = 'uk';
+  else if (tld === 'com.au' || tld === 'au') region = 'au';
+  else if (tld === 'fr') region = 'fr';
+  else if (tld === 'de') region = 'de';
+  else if (tld === 'it') region = 'it';
+  else if (tld === 'es') region = 'es';
+  else if (tld === 'in') region = 'in';
+  else if (tld === 'co.jp' || tld === 'jp') region = 'jp';
+  else if (tld === 'com') region = 'us';
+  else {
+    // Fallback to host detection if no label found
+    if (window.location.host.includes('.ca')) region = 'ca';
+    else if (window.location.host.includes('.co.uk')) region = 'uk';
+    else if (window.location.host.includes('.com.au')) region = 'au';
+    else if (window.location.host.includes('.fr')) region = 'fr';
+    else if (window.location.host.includes('.de')) region = 'de';
+    else if (window.location.host.includes('.it')) region = 'it';
+    else if (window.location.host.includes('.es')) region = 'es';
+    else if (window.location.host.includes('.in')) region = 'in';
+    else if (window.location.host.includes('.co.jp')) region = 'jp';
+  }
+
+  try {
+    const res = await fetch(`https://api.audnex.us/books/${asin}?region=${region}`);
+    if (res.ok) {
+      const data = await res.json();
+      const details = {};
+      if (data.isbn) {
+        details['ISBN-13'] = data.isbn;
+      }
+      if (data.genres) {
+        details.Categories = data.genres.map(g => cleanText(g.name));
+      }
+      if (data.rating) {
+        details['Average Rating'] = parseFloat(data.rating);
+      }
+      logMarian("Fetched extra data from Audnexus for Amazon Audiobook", details);
+      return details;
+    }
+  } catch (e) {
+    logMarian("Failed to fetch Audnexus data for Amazon Audiobook", e);
+  }
+  return {};
 }
 
 async function getCover() {
@@ -235,10 +292,10 @@ function getAudibleDetails() {
     }
 
     // Match any Audible.<TLD> Release Date
-    if (/^Audible\.[^\s]+ Release Date$/i.test(label)) {
+    const regionMatch = label?.match(/^Audible\.([a-z.]+) Release Date$/i);
+    if (regionMatch) {
       details['Publication date'] = value;
-    } else if (label === 'Audible.com Release Date') {
-      details['Publication date'] = value;
+      details['_detectedRegion'] = regionMatch[1].toLowerCase();
     } else if (label === 'Program Type') {
       details['Reading Format'] = value;
       details['Edition Format'] = "Audible";

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -150,6 +150,7 @@ async function fetchAudnexusDetails(asin, audibleDetails) {
     }
   } catch (e) {
     logMarian("Failed to fetch Audnexus data for Amazon Audiobook", e);
+    if (e.message?.startsWith('MISSING_PERMISSION:')) throw e;
   }
   return {};
 }

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -85,7 +85,9 @@ class amazonScraper extends Extractor {
 
     const audibleAsin = getAudibleAsin();
     let apiPromise = {};
-    if (audibleAsin) {
+    if (audibleAsin &&
+      (bookDetails["Reading Format"] === "Audiobook" || audibleDetails["Reading Format"] === "Audiobook")
+    ) {
       delete bookDetails["ASIN"];
       bookDetails["Amazon ASIN"] = asin;
       audibleDetails["ASIN"] = audibleAsin;

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -117,6 +117,7 @@ async function fetchApiDetails(asin, audibleDetails) {
   }
 
   let tld = audibleDetails['_detectedRegion'] || document.location.host.split("amazon").pop();
+  console.log("Tldldd", tld);
   const region = getRegion(tld);
 
   return await collectObject([
@@ -266,7 +267,7 @@ function getAudibleDetails() {
     }
 
     // Match any Audible.<TLD> Release Date
-    const regionMatch = label?.match(/^Audible\.([a-z.]+) Release Date$/i);
+    const regionMatch = label?.match(/^Audible(\.[a-z.]+) Release Date$/i);
     if (regionMatch) {
       details['Publication date'] = value;
       details['_detectedRegion'] = regionMatch[1].toLowerCase();

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -50,7 +50,7 @@ class amazonScraper extends Extractor {
 
     // combined publisher date
     const pubDate = bookDetails["Publisher"]?.match(/^(?<pub>[^(;]+?)(?:; (?<edition>[\w ]+))? \((?<date>\d{1,2} \w+ \d{4})\)$/);
-    if (pubDate !== undefined) {
+    if (pubDate != null) {
       bookDetails["Publisher"] = cleanText(pubDate.groups["pub"]);
       bookDetails["Publication date"] = pubDate.groups["date"];
       if (pubDate.groups["edition"]) {
@@ -159,7 +159,7 @@ async function getCover() {
 
   const coverList = Array.from(covers)
     .filter((x) => !x.includes("01RmK+J4pJL.gif")); // filter out no image image
-  console.log(coverList)
+  // console.log(coverList)
 
   const coverRes = await getCoverData(coverList);
   if (coverRes.imgScore === 0) return {}

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -34,7 +34,7 @@ class amazonScraper extends Extractor {
     const contributors = extractAmazonContributors();
 
     bookDetails["Edition Format"] = getSelectedFormat() || '';
-    bookDetails["Title"] = document.querySelector('#productTitle')?.innerText.trim();
+    bookDetails["Title"] = cleanText(document.querySelector('#productTitle')?.innerText);
     bookDetails["Description"] = getBookDescription() || '';
     bookDetails["Contributors"] = contributors;
 
@@ -49,10 +49,10 @@ class amazonScraper extends Extractor {
     // combined publisher date
     const pubDate = bookDetails["Publisher"]?.match(/^(?<pub>[^(;]+?)(?:; (?<edition>[\w ]+))? \((?<date>\d{1,2} \w+ \d{4})\)$/);
     if (pubDate != undefined) {
-      bookDetails["Publisher"] = pubDate.groups["pub"].trim();
+      bookDetails["Publisher"] = cleanText(pubDate.groups["pub"]);
       bookDetails["Publication date"] = pubDate.groups["date"];
       if (pubDate.groups["edition"]) {
-        bookDetails["Edition Information"] = pubDate.groups["edition"].trim();
+        bookDetails["Edition Information"] = cleanText(pubDate.groups["edition"]);
       }
     }
 
@@ -254,7 +254,7 @@ function getDetailBullets() {
   // Double check book series
   const series = document.querySelector("div[data-feature-name='seriesBulletWidget'] a")
   if (!details["Series"] && series != undefined) {
-    const match = series.textContent.trim().match(/Book (\d+) of \d+: (.+)/i);
+    const match = cleanText(series.textContent).match(/Book (\d+) of \d+: (.+)/i);
     if (match) {
       details['Series'] = match[2];
       details['Series Place'] = match[1];
@@ -272,8 +272,8 @@ function getAudibleDetails() {
   const rows = table.querySelectorAll('tr');
 
   rows.forEach(row => {
-    const label = row.querySelector('th span')?.textContent?.trim();
-    const value = row.querySelector('td')?.innerText?.trim();
+    const label = cleanText(row.querySelector('th span')?.textContent);
+    const value = cleanText(row.querySelector('td')?.innerText);
     const match = bookSeriesRegex.exec(label) || bookSeriesRegex.exec(value);
 
     // Handle book series special case
@@ -327,7 +327,7 @@ function getBookDescription() {
 function getSelectedFormat() {
   const selected = document.querySelector('#tmmSwatches .swatchElement.selected .slot-title span[aria-label]');
   if (selected) {
-    return selected.getAttribute('aria-label')?.replace(' Format:', '').trim();
+    return cleanText(selected.getAttribute('aria-label')?.replace(' Format:', ''));
   }
   return null;
 }
@@ -337,8 +337,8 @@ function extractAmazonContributors() {
 
   const authorSpans = document.querySelectorAll('#bylineInfo .author');
   authorSpans.forEach(span => {
-    const name = span.querySelector('a')?.innerText.trim();
-    const roleText = span.querySelector('.contribution span')?.innerText.trim();
+    const name = cleanText(span.querySelector('a')?.innerText);
+    const roleText = cleanText(span.querySelector('.contribution span')?.innerText);
     let roles = [];
 
     if (roleText) {
@@ -346,7 +346,7 @@ function extractAmazonContributors() {
       const roleMatch = roleText.match(/\(([^)]+)\)/);
       if (roleMatch) {
         // Split by comma and trim each role
-        roles = roleMatch[1].split(',').map(r => r.trim());
+        roles = roleMatch[1].split(',').map(cleanText);
       }
     } else {
       roles.push("Contributor"); // fallback if role is missing

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -49,7 +49,7 @@ class amazonScraper extends Extractor {
 
     // combined publisher date
     const pubDate = bookDetails["Publisher"]?.match(/^(?<pub>[^(;]+?)(?:; (?<edition>[\w ]+))? \((?<date>\d{1,2} \w+ \d{4})\)$/);
-    if (pubDate != undefined) {
+    if (pubDate !== undefined) {
       bookDetails["Publisher"] = cleanText(pubDate.groups["pub"]);
       bookDetails["Publication date"] = pubDate.groups["date"];
       if (pubDate.groups["edition"]) {
@@ -82,7 +82,14 @@ class amazonScraper extends Extractor {
       bookDetails["ISBN-10"] = asin;
     }
 
-    const audnexusPromise = fetchAudnexusDetails(asin, audibleDetails);
+    const audibleAsin = getAudibleAsin();
+    let audnexusPromise = undefined;
+    if (audibleAsin && audibleAsin !== asin) {
+      delete bookDetails["ASIN"];
+      bookDetails["Amazon ASIN"] = asin;
+      audibleDetails["ASIN"] = audibleAsin;
+      audnexusPromise = fetchAudnexusDetails(audibleAsin, audibleDetails);
+    }
 
     const mergedDetails = await collectObject([
       bookDetails,
@@ -185,7 +192,9 @@ async function getCover() {
   });
 
   // get original image
-  covers.forEach((value) => value && covers.add(getHighResImageUrl(value)));
+  [...covers]
+    .filter(i => i)
+    .forEach((url) => { covers.add(getHighResImageUrl(url)); });
 
   const coverList = Array.from(covers)
     .filter((x) => !x.includes("01RmK+J4pJL.gif")); // filter out no image image
@@ -324,6 +333,27 @@ function getBookDescription() {
   if (!container) return '';
 
   return getFormattedText(container);
+}
+
+function getAudibleAsin() {
+  // 1. Check hidden input
+  const hiddenInput = document.querySelector('input[name="audibleASIN"]');
+  if (hiddenInput?.value) return hiddenInput.value;
+  // 2. Check Sample Player JSON
+  const samplePlayer = document.querySelector('[data-play-audiosample-cloud-player]');
+  if (samplePlayer) {
+    try {
+      const config = JSON.parse(samplePlayer.dataset.playAudiosampleCloudPlayer);
+      const urlParams = new URLSearchParams(config.cloudPlayerUrl.split('?')[1]);
+      const asin = urlParams.get('asin');
+      if (asin) return asin;
+    } catch { }
+  }
+  // 3. Check Swatches
+  const audioSwatch = Array.from(document.querySelectorAll('#tmmSwatches .swatchElement'))
+    .find(el => el.textContent.toLowerCase().includes('audiobook') || el.textContent.toLowerCase().includes('audible'));
+
+  return audioSwatch?.dataset.asin || audioSwatch?.dataset.defaultasin || null;
 }
 
 function getSelectedFormat() {

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -117,7 +117,6 @@ async function fetchApiDetails(asin, audibleDetails) {
   }
 
   let tld = audibleDetails['_detectedRegion'] || document.location.host.split("amazon").pop();
-  console.log("Tldldd", tld);
   const region = getRegion(tld);
 
   return await collectObject([

--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -85,7 +85,7 @@ class amazonScraper extends Extractor {
 
     const audibleAsin = getAudibleAsin();
     let apiPromise = {};
-    if (audibleAsin && audibleAsin !== asin) {
+    if (audibleAsin) {
       delete bookDetails["ASIN"];
       bookDetails["Amazon ASIN"] = asin;
       audibleDetails["ASIN"] = audibleAsin;
@@ -95,7 +95,7 @@ class amazonScraper extends Extractor {
     const mergedDetails = await collectObject([
       bookDetails,
       audibleDetails,
-      apiPromise, // overwriting contributor scraped data from amazon
+      apiPromise,
       coverData,
     ]);
 

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -108,7 +108,7 @@ export async function fetchAudnexusApiDetails(asin, region = null) {
         if (!resHtml) return details;
         data = JSON.parse(resHtml);
         if (!data) return details;
-    } catch {
+    } catch (e) {
         if (e.message?.startsWith('MISSING_PERMISSION:')) throw e;
         logMarian("Audnexus fetch failed", e);
         return details;

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -5,7 +5,7 @@ class audibleScraper extends Extractor {
     get _name() { return "Audible Extractor"; }
     needsReload = false;
     _sitePatterns = [
-        /^https:\/\/(?:www\.)?audible\.[a-z.]+\/.*?([A-Z0-9]{10})\b/,
+        /^https:\/\/(?:www\.)?audible\.[a-z.]+\/.*?(?<=\/)(?<asin>B[\dA-Z]{9}|\d{9}(?:X|\d))\b/,
     ];
 
     async getDetails() {

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -65,18 +65,39 @@ async function getAudibleDetails() {
     }
 }
 
-async function fetchAudnexusApiDetails(asin) {
-    const details = {};
+/**
+ * get a region for Audnexus API, defaulting to us 
+ *
+ * @param {string} tld
+ */
+export function getRegion(tld) {
     let region = 'us';
-    if (window.location.host.includes('.ca')) region = 'ca';
-    else if (window.location.host.includes('.co.uk')) region = 'uk';
-    else if (window.location.host.includes('.com.au')) region = 'au';
-    else if (window.location.host.includes('.fr')) region = 'fr';
-    else if (window.location.host.includes('.de')) region = 'de';
-    else if (window.location.host.includes('.it')) region = 'it';
-    else if (window.location.host.includes('.es')) region = 'es';
-    else if (window.location.host.includes('.in')) region = 'in';
-    else if (window.location.host.includes('.co.jp')) region = 'jp';
+    if (false);
+    else if (tld.endsWith('.ca')) region = 'ca';
+    else if (tld.endsWith('.co.uk')) region = 'uk';
+    else if (tld.endsWith('.com.au')) region = 'au';
+    else if (tld.endsWith('.fr')) region = 'fr';
+    else if (tld.endsWith('.de')) region = 'de';
+    else if (tld.endsWith('.it')) region = 'it';
+    else if (tld.endsWith('.es')) region = 'es';
+    else if (tld.endsWith('.in')) region = 'in';
+    else if (tld.endsWith('.co.jp')) region = 'jp';
+    else if (tld.endsWith('.com.mx')) region = 'mx';
+
+    return region;
+}
+
+/**
+ * @param {string} asin - audible ASIN
+ * @param {string} [region=null] API region to search in
+ */
+export async function fetchAudnexusApiDetails(asin, region = null) {
+    const details = {};
+    if (region == null) {
+        if (!window.location.host.includes('audible.')) throw new Error("Must provide region");
+        const tld = window.location.host.split("audible").pop()
+        region = getRegion(tld);
+    }
 
     const resHtml = await fetchBackground(`https://api.audnex.us/books/${asin}?region=${region}`);
     if (!resHtml) return details;
@@ -142,14 +163,24 @@ async function fetchAudnexusApiDetails(asin) {
     return details;
 }
 
-async function fetchAudibleApiDetails(asin) {
+/**
+ * @param {string} asin - audible ASIN;
+ * @param {string} [tld=null] top level domain to use for API
+ */
+export async function fetchAudibleApiDetails(asin, tld = null) {
     const details = {};
     let resHtml;
+
+    if (tld == null) {
+        if (!window.location.host.includes('audible.')) throw new Error("Must provide tld");
+        tld = ".com";
+        tld = window.location.host.split("audible").pop();
+    }
+
+    if (!tld.startsWith(".")) tld = `.${tld}`;
+    const apiHost = `api.audible${tld}`;
+
     try {
-        let apiHost = 'api.audible.com';
-        if (window.location.host.includes('audible.')) {
-            apiHost = window.location.host.replace(/^www\./, 'api.');
-        }
         resHtml = await fetchBackground(`https://${apiHost}/1.0/catalog/products/${asin}?response_groups=category_ladders,contributors,media,product_attrs,product_desc,product_details,product_extended_attrs,rating,series&image_sizes=512,1024`);
     } catch (e) {
         if (e.message?.startsWith('MISSING_PERMISSION:')) throw e;
@@ -223,9 +254,9 @@ async function fetchAudibleApiDetails(asin) {
                 }
             }
         }
-        if (categories.size > 0) {
-            details.Categories = Array.from(categories);
-        }
+        // if (categories.size > 0) {
+        //     details.Categories = Array.from(categories);
+        // }
     }
 
     // if (data.rating) {

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -1,32 +1,9 @@
-import {
-    cleanText,
-    clearDeepQueryCache,
-    getFormattedText,
-    getImageScore,
-    logMarian,
-    queryAllDeep,
-    queryDeep,
-    withTimeout,
-} from '../shared/utils.js';
+import { cleanText, getFormattedText, logMarian } from '../shared/utils.js';
 import { Extractor } from './AbstractExtractor.js';
-
-const DEBUG = false;
-
-// Known shadow-hosts / component surfaces to search
-// Audible uses a lot of web components
-const KNOWN_DEEP_HOSTS = [
-    'adbl-product-details',
-    'adbl-product-metadata',
-    'adbl-title-lockup',
-    'adbl-product-hero',
-    'adbl-product-image',
-    '[data-automation-id="titleSubtitle"]',
-    '[data-automation-id="hero-metadata"]',
-    '[data-automation-id="hero-art"]',
-];
 
 class audibleScraper extends Extractor {
     get _name() { return "Audible Extractor"; }
+    needsReload = false;
     _sitePatterns = [
         /^https?:\/\/(www\.)?audible\.[a-z.]+\/pd\/(?:[^/]+\/)*[A-Z0-9]{10}(?:\?.*)?$/,
     ];
@@ -37,73 +14,37 @@ class audibleScraper extends Extractor {
 }
 
 async function getAudibleDetails() {
-    clearDeepQueryCache();
     const details = {};
-    const asyncJobs = [];
 
     try {
         const asin = extractAsinFromUrl(window.location.href);
 
-        if (asin) {
-            details.ASIN = asin;
-            // Try to fetch data from Audible API
-            try {
-                const audnexusData = await fetchAudnexusApiDetails(asin);
-                if (audnexusData && Object.keys(audnexusData).length > 0) {
-                    Object.assign(details, audnexusData);
-                    logMarian('Audnexus extraction complete', audnexusData);
-                } else {
-                    const audibleData = await fetchAudibleApiDetails(asin);
-                    if (audibleData && Object.keys(audibleData).length > 0) {
-                        Object.assign(details, audibleData);
-                        logMarian('Audible API extraction complete', audibleData);
-                    }
-                }
-            } catch (err) {
-                logMarian('Audible API extraction failed, falling back to DOM scraping', err);
+        if (!asin) {
+            logMarian('Audible extraction failed: No ASIN found in URL');
+            return details;
+        }
+
+        details.ASIN = asin;
+
+        try {
+            const audibleData = await fetchAudibleApiDetails(asin);
+            if (audibleData && Object.keys(audibleData).length > 0) {
+                Object.assign(details, audibleData);
+                logMarian('Audible API extraction complete', audibleData);
             }
+        } catch (err) {
+            logMarian('API extraction failed', err);
         }
 
-        // Only fallback to DOM scraping for fields not already extracted
-        const cover = getPrimaryImage();
-        if (!details.img && cover?.src) {
-            const src = cover.src;
-            details.img = src;
-            asyncJobs.push(
-                withTimeout(getImageScore(src), 1500, 0)
-                    .then(s => { details.imgScore = s; })
-                    .catch(e => { details.imgScore = 0; })
-            );
-        } else if (details.img && details.imgScore === undefined) {
-            asyncJobs.push(
-                withTimeout(getImageScore(details.img), 1500, 0)
-                    .then(s => { details.imgScore = s; })
-                    .catch(e => { details.imgScore = 0; })
-            );
-        }
-
-        if (!details.Title) {
-            const title = getFirstText([
-                '[data-automation-id="adbl-product-title"]',
-                'adbl-title-lockup [slot="title"]',
-                'adbl-product-hero [slot="title"]',
-                'meta[property="og:title"]',
-                'title',
-            ]);
-            if (title) details.Title = title;
-        }
-
-        if (!details.Description) {
-            const description = getDescription();
-            if (description) details.Description = description;
-        }
-
-        // Collect DOM metadata but prefer API data
-        const domMetadata = collectMetadata();
-        for (const [key, value] of Object.entries(domMetadata)) {
-            if (!details[key]) {
-                details[key] = value;
+        // overwrite with better data when available
+        try {
+            const audnexusData = await fetchAudnexusApiDetails(asin);
+            if (audnexusData && Object.keys(audnexusData).length > 0) {
+                Object.assign(details, audnexusData);
+                logMarian('Audnexus extraction complete', audnexusData);
             }
+        } catch (err) {
+            logMarian('Audnexus extraction failed', err);
         }
 
         if (!details['Reading Format']) details['Reading Format'] = 'Audiobook';
@@ -114,51 +55,12 @@ async function getAudibleDetails() {
         delete details.Edition;
         delete details.Version;
 
-        await Promise.allSettled(asyncJobs);
-
         logMarian('Audible extraction complete', details);
         return details;
     } catch (e) {
         logMarian('Audible extraction failed', { error: String(e) });
         return details;
     }
-}
-
-function collectMetadata() {
-    const contributorMap = new Map();
-    const fields = {};
-    // Collect data from product metadata, product details, and hero from DOM
-    const pairs = [
-        ...collectListPairs(),
-        ...collectMetadataLines(),
-        ...collectTablePairs(),
-    ];
-
-    // Figure out how they map to the values we show in the UI
-    for (const { label, values } of pairs) {
-        applyPair(fields, contributorMap, label, values);
-    }
-
-    // Serialize all of the contributors found
-    const contributors = Array.from(contributorMap.entries()).map(([name, roles]) => ({
-        name,
-        roles: Array.from(roles),
-    }));
-    if (contributors.length) fields.Contributors = contributors;
-    return fields;
-}
-
-function collectListPairs() {
-    // Hero subtitle list renders as free text ("Label: value") inside shadow roots
-    return queryAllDeep('[data-automation-id="hero-metadata"] li.bc-list-item, [data-automation-id="titleSubtitle"] li.bc-list-item', KNOWN_DEEP_HOSTS)
-        .map(node => cleanText(node.textContent))
-        .filter(Boolean)
-        .map(text => {
-            const match = text.match(/^([^:]+):\s*(.+)$/); // "Label: Value" pair
-            if (!match) return null;
-            return { label: match[1], values: cleanValues([match[2]]) };
-        })
-        .filter(Boolean);
 }
 
 async function fetchAudnexusApiDetails(asin) {
@@ -227,13 +129,13 @@ async function fetchAudnexusApiDetails(asin) {
     }
     details['Edition Format'] = 'Audible';
 
-    if (data.genres) {
-        details.Categories = data.genres.map(g => cleanText(g.name));
-    }
-
-    if (data.rating && +data.rating != 0) {
-        details['Average Rating'] = parseFloat(data.rating);
-    }
+    // if (data.genres) {
+    //     details.Categories = data.genres.map(g => cleanText(g.name));
+    // }
+    //
+    // if (data.rating && parseFloat(data.rating) !== 0) {
+    //     details['Average Rating'] = parseFloat(data.rating);
+    // }
 
     return details;
 }
@@ -314,298 +216,15 @@ async function fetchAudibleApiDetails(asin) {
         }
     }
 
+    // if (data.rating) {
+    //     const rating = data.rating.overall_distribution?.display_average_rating;
+    //     if (rating) details['Average Rating'] = parseFloat(rating);
+    //
+    //     const count = data.rating.overall_distribution?.num_ratings;
+    //     if (count) details['Ratings Count'] = count;
+    // }
+
     return details;
-}
-
-function collectMetadataLines() {
-    const pairs = [];
-    queryAllDeep('adbl-product-metadata', KNOWN_DEEP_HOSTS).forEach(host => {
-        const root = host.shadowRoot || host;
-        // Each metadata line exposes optional label/value slots per locale variant
-        const lines = root?.querySelectorAll?.('.line[role="group"], [data-automation-id="metadata-line"]');
-        if (!lines) return;
-
-        for (const line of lines) {
-            const labelEl = line.querySelector('.label, [slot="label"], [data-automation-id="metadata-label"], dt');
-            const label = cleanText(labelEl?.textContent || line.getAttribute('key'));
-            if (!label) continue;
-            const valueNodes = line.querySelectorAll('.values a, .values .text, .values span, [slot="values"] *, [data-automation-id="metadata-value"] *, dd, .value');
-            const values = cleanValues(
-                valueNodes.length ? Array.from(valueNodes, node => node.textContent) : [line.textContent]
-            );
-            if (values.length) pairs.push({ label, values });
-        }
-    });
-    return pairs;
-}
-
-function collectTablePairs() {
-    const rows = document.querySelectorAll('#audibleProductDetails table tr, #productDetails table tr');
-    const pairs = [];
-    for (const row of rows) {
-        const label = cleanText(row.querySelector('th, td:first-child')?.textContent);
-        const value = cleanText(row.querySelector('td:last-child')?.textContent);
-        if (label && value) pairs.push({ label, values: [value] });
-    }
-    return pairs;
-}
-
-function applyPair(fields, contributors, label, rawValues) {
-    const normalized = normalizeLabel(label);
-    const values = cleanValues(rawValues);
-    if (!normalized || !values.length) return;
-
-    let handled = true;
-
-    switch (normalized) {
-        case 'by':
-        case 'written by':
-        case 'author':
-        case 'authors':
-            addContributors(contributors, values, 'Author');
-            break;
-        case 'narrated by':
-        case 'narrator':
-        case 'narrators':
-            addContributors(contributors, values, 'Narrator');
-            break;
-        case 'performed by':
-        case 'performed':
-            addContributors(contributors, values, 'Narrator');
-            break;
-        case 'directed by':
-            addContributors(contributors, values, 'Director');
-            break;
-        case 'translated by':
-        case 'translator':
-            addContributors(contributors, values, 'Translator');
-            break;
-        case 'composer':
-            addContributors(contributors, values, 'Composer');
-            break;
-        case 'publisher':
-            setField(fields, 'Publisher', values.join(', '));
-            break;
-        case 'language':
-            setField(fields, 'Language', values.join(', '));
-            break;
-        case 'length':
-        case 'listening length':
-        case 'runtime':
-        case 'runtime length':
-        case 'audio length':
-            setField(fields, 'Listening Length', parseListeningLength(values[0]));
-            break;
-        case 'release date':
-        case 'publication date':
-        case 'audible release date':
-        case 'audible.com release date':
-        case 'audible com release date':
-            setField(fields, 'Publication date', values[0]);
-            break;
-        case 'program type':
-            applyProgramType(fields, values[0]);
-            break;
-        case 'format':
-        case 'edition':
-            fields['Edition Format'] ??= values[0];
-            break;
-        case 'version':
-            setField(fields, 'Edition Information', values[0]);
-            break;
-        case 'series':
-            for (const value of values) {
-                applySeries(fields, value);
-            }
-            break;
-        case 'series number':
-        case 'series place':
-            setField(fields, 'Series Place', values[0]);
-            break;
-        case 'asin':
-            fields.ASIN ??= values[0];
-            break;
-        default:
-            handled = false;
-            if (DEBUG) logMarian('Unhandled label', { label, normalized, values });
-            break;
-    }
-
-}
-
-function addContributors(map, values, role) {
-    for (const name of values.flatMap(splitContributorNames)) {
-        if (!name) continue;
-        const roles = map.get(name) || new Set();
-        roles.add(role);
-        map.set(name, roles);
-    }
-}
-
-function splitContributorNames(value) {
-    const chunks = value
-        .split(/\s+(?:and|&)\s+/i) // Split between "and" and "&"
-        .map(cleanText)
-        .filter(Boolean);
-    const out = [];
-    for (const chunk of chunks) {
-        if (/,.*,.*/.test(chunk)) { // Check for two commas
-            // Likely "A, B, C" list
-            out.push(...chunk.split(/\s*,\s*/).map(cleanText).filter(Boolean)); // Split on commas
-        } else {
-            out.push(chunk);
-        }
-    }
-    return out;
-}
-
-function setField(fields, key, value) {
-    if (!value || fields[key]) return;
-    if (Array.isArray(value) && !value.length) return;
-    fields[key] = value;
-}
-
-function applyProgramType(fields, value) {
-    if (!value) return;
-    const lower = value.toLowerCase();
-    if (lower.includes('podcast')) {
-        setField(fields, 'Reading Format', 'Podcast');
-    } else if (lower.includes('audio')) {
-        setField(fields, 'Reading Format', 'Audiobook');
-    } else {
-        setField(fields, 'Reading Format', value);
-    }
-    fields['Edition Format'] ??= value;
-}
-
-function applySeries(fields, value) {
-    const text = cleanText(value);
-    if (!text) return;
-    const position = parseSeriesPlace(text);
-    // remove patterns like ", Book 3", "Vol. 2", "#1.5" etc. at the end
-    const SERIES_TRAIL = /(?:,?\s*(?:Book|Volume|Vol\.?|Part)\s*\d+(?:\.\d+)?|#\s*\d+(?:\.\d+)?)\s*$/i;
-    // remove patterns like "Book 2: " or "Vol. 3 - " at the beginning
-    const SERIES_LEAD = /^(?:Book|Volume|Vol\.?|Part|#)\s*\d+(?:\.\d+)?\s*[:,\-\u2013]\s*/i;
-    // remove trailing parentheses like "(Book 2)" at the end
-    const SERIES_PAREN = /\(\s*(?:Book|Volume|Vol\.?|Part|#)\s*\d+(?:\.\d+)?\s*\)\s*$/i;
-
-    let name = text
-        .replace(SERIES_TRAIL, '')
-        .replace(SERIES_LEAD, '')
-        .replace(SERIES_PAREN, '');
-    name = name.replace(/^[\s,:-]+|[\s,:-]+$/g, '').trim();
-    if (name) setField(fields, 'Series', name);
-    if (position) setField(fields, 'Series Place', position);
-}
-
-function parseSeriesPlace(value) {
-    // Extracts a number after keywords like “Book” or “#”
-    const match = value.match(/(?:Book|Volume|Vol\.?|Part|#)\s*(\d+(?:\.\d+)?)/i);
-    return match ? match[1] : null;
-}
-
-function parseListeningLength(value) {
-    if (!value) return value;
-    const text = cleanText(Array.isArray(value) ? value.join(' ') : value);
-    const hours = +(text.match(/(\d+)\s*(?:hours?|hrs?)/i)?.[1] || 0);
-    const minutes = +(text.match(/(\d+)\s*(?:minutes?|mins?)/i)?.[1] || 0);
-    const seconds = +(text.match(/(\d+)\s*(?:seconds?|secs?)/i)?.[1] || 0);
-    const parts = [];
-    if (hours) parts.push(`${hours} hours`);
-    if (minutes) parts.push(`${minutes} minutes`);
-    if (seconds) parts.push(`${seconds} seconds`);
-    return parts.length ? parts : text;
-}
-
-function getDescription() {
-    const selectors = [
-        'adbl-product-details [slot="summary"]',
-        'adbl-product-details adbl-text-block[slot="summary"]',
-        '[data-automation-id="productDescription"]',
-        '[data-automation-id="adbl-product-description"]',
-        '#publisher-summary',
-        '#publisher-s-summary',
-        '#product-description',
-    ];
-
-    for (const selector of selectors) {
-        const el = queryDeep(selector, KNOWN_DEEP_HOSTS);
-        if (!el) continue;
-        const text = getFormattedText(el);
-        if (text) return text;
-    }
-
-    const meta = document.querySelector('meta[name="description"]')?.getAttribute('content');
-    return cleanText(meta);
-}
-
-function getPrimaryImage() {
-    return (
-        queryDeep('.adbl-product-image img', KNOWN_DEEP_HOSTS) ||
-        queryDeep('[data-automation-id="hero-art"] img', KNOWN_DEEP_HOSTS) ||
-        queryDeep('img.bc-pub-media', KNOWN_DEEP_HOSTS) ||
-        document.querySelector('img[alt*="cover art" i]') ||
-        document.querySelector('img[alt*="portada" i]')
-    );
-}
-
-function getFirstText(selectors) {
-    for (const selector of selectors) {
-        if (selector === 'title') {
-            const text = cleanText(document.title);
-            if (text) return text;
-            continue;
-        }
-
-        if (selector.startsWith('meta[')) {
-            const meta = document.querySelector(selector);
-            const content = cleanText(meta?.getAttribute('content'));
-            if (content) return content;
-            continue;
-        }
-
-        const el = queryDeep(selector, KNOWN_DEEP_HOSTS);
-        const text = cleanText(el?.textContent);
-        if (text) return text;
-    }
-    return null;
-}
-
-/**
- * Deduplicate, normalize, and explode composite value strings.
- *
- * @param {Array<string | null | undefined>} values Raw value candidates (possibly pipe-delimited).
- * @returns {string[]} Unique sanitized values.
- */
-function cleanValues(values) {
-    const seen = new Set();
-    const result = [];
-
-    for (const value of values) {
-        if (!value) continue;
-        const cleaned = cleanText(value);
-        if (!cleaned) continue;
-
-        for (const part of cleaned.split(/\s*\|\s*/)) {
-            const piece = cleanText(part);
-            if (piece && !seen.has(piece)) {
-                seen.add(piece);
-                result.push(piece);
-            }
-        }
-    }
-
-    return result;
-}
-
-/**
- * Produce a lowercase variant of a label after cleaning it.
- *
- * @param {string | null | undefined} label Label text to normalize.
- * @returns {string} Lowercase sanitized label.
- */
-function normalizeLabel(label) {
-    return cleanText(label).toLowerCase();
 }
 
 /**

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -121,7 +121,7 @@ export async function fetchAudnexusApiDetails(asin, region = null) {
     if (data.image) details.img = data.image;
     if (data.publisherName) details.Publisher = cleanText(data.publisherName);
     if (data.releaseDate) details['Publication date'] = new Date(data.releaseDate).toISOString().split('T')[0];
-    if (data.language) details.Language = data.language;
+    if (data.language) details.Language = data.language.charAt(0).toUpperCase() + data.language.slice(1);
     if (data.isbn) details['ISBN-13'] = data.isbn;
 
     const contributors = [];
@@ -214,7 +214,7 @@ export async function fetchAudibleApiDetails(asin, tld = null) {
 
     if (data.publisher_name) details.Publisher = cleanText(data.publisher_name);
     if (data.release_date) details['Publication date'] = data.release_date;
-    if (data.language) details.Language = data.language;
+    if (data.language) details.Language = data.language.charAt(0).toUpperCase() + data.language.slice(1);
     if (data.isbn) details['ISBN-13'] = data.isbn;
 
     const contributors = [];

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -1,4 +1,4 @@
-import { cleanText, getFormattedText, logMarian } from '../shared/utils.js';
+import { cleanText, fetchBackground, getFormattedText, logMarian } from '../shared/utils.js';
 import { Extractor } from './AbstractExtractor.js';
 
 class audibleScraper extends Extractor {
@@ -76,9 +76,9 @@ async function fetchAudnexusApiDetails(asin) {
     else if (window.location.host.includes('.in')) region = 'in';
     else if (window.location.host.includes('.co.jp')) region = 'jp';
 
-    const res = await fetch(`https://api.audnex.us/books/${asin}?region=${region}`);
-    if (!res.ok) return details;
-    const data = await res.json();
+    const resHtml = await fetchBackground(`https://api.audnex.us/books/${asin}?region=${region}`);
+    if (!resHtml) return details;
+    const data = JSON.parse(resHtml);
 
     if (data.title) details.Title = data.title + (data.subtitle ? `: ${data.subtitle}` : '');
     if (data.summary) {
@@ -142,9 +142,18 @@ async function fetchAudnexusApiDetails(asin) {
 
 async function fetchAudibleApiDetails(asin) {
     const details = {};
-    const res = await fetch(`https://api.audible.com/1.0/catalog/products/${asin}?response_groups=category_ladders,contributors,media,product_attrs,product_desc,product_details,product_extended_attrs,rating,series&image_sizes=512,1024`);
-    if (!res.ok) return details;
-    const json = await res.json();
+    let resHtml;
+    try {
+        let apiHost = 'api.audible.com';
+        if (window.location.host.includes('audible.')) {
+            apiHost = window.location.host.replace(/^www\./, 'api.');
+        }
+        resHtml = await fetchBackground(`https://${apiHost}/1.0/catalog/products/${asin}?response_groups=category_ladders,contributors,media,product_attrs,product_desc,product_details,product_extended_attrs,rating,series&image_sizes=512,1024`);
+    } catch (e) {
+        return details;
+    }
+    if (!resHtml) return details;
+    const json = JSON.parse(resHtml);
     const data = json.product;
     if (!data) return details;
 

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -34,6 +34,7 @@ async function getAudibleDetails() {
             }
         } catch (err) {
             logMarian('API extraction failed', err);
+            if (err.message?.startsWith('MISSING_PERMISSION:')) throw err;
         }
 
         // overwrite with better data when available
@@ -45,11 +46,12 @@ async function getAudibleDetails() {
             }
         } catch (err) {
             logMarian('Audnexus extraction failed', err);
+            if (err.message?.startsWith('MISSING_PERMISSION:')) throw err;
         }
 
         if (!details['Reading Format']) details['Reading Format'] = 'Audiobook';
         if (!details['Edition Format'] && details['Reading Format']) {
-            details['Edition Format'] = details['Reading Format'];
+            details['Edition Format'] = "Audible";
         }
 
         delete details.Edition;
@@ -150,6 +152,7 @@ async function fetchAudibleApiDetails(asin) {
         }
         resHtml = await fetchBackground(`https://${apiHost}/1.0/catalog/products/${asin}?response_groups=category_ladders,contributors,media,product_attrs,product_desc,product_details,product_extended_attrs,rating,series&image_sizes=512,1024`);
     } catch (e) {
+        if (e.message?.startsWith('MISSING_PERMISSION:')) throw e;
         return details;
     }
     if (!resHtml) return details;

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -5,7 +5,7 @@ class audibleScraper extends Extractor {
     get _name() { return "Audible Extractor"; }
     needsReload = false;
     _sitePatterns = [
-        /^https:\/\/(?:www\.)?audible\.[a-z.]+\/.*?(?<=\/)(?<asin>B[\dA-Z]{9}|\d{9}(?:X|\d))\b/,
+        /^https:\/\/(?:www\.)?audible\.[a-z.]+\/+(?:pd|p|ac)\/+[^/]+\/+(?<asin>B[\dA-Z]{9}|\d{9}(?:X|\d))\b/
     ];
 
     async getDetails() {

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -5,7 +5,7 @@ class audibleScraper extends Extractor {
     get _name() { return "Audible Extractor"; }
     needsReload = false;
     _sitePatterns = [
-        /^https?:\/\/(www\.)?audible\.[a-z.]+\/pd\/(?:[^/]+\/)*[A-Z0-9]{10}(?:\?.*)?$/,
+        /^https:\/\/(?:www\.)?audible\.[a-z.]+\/.*?([A-Z0-9]{10})\b/,
     ];
 
     async getDetails() {

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -5,19 +5,24 @@ class audibleScraper extends Extractor {
     get _name() { return "Audible Extractor"; }
     needsReload = false;
     _sitePatterns = [
-        /^https:\/\/(?:www\.)?audible\.[a-z.]+\/+(?:pd|p|ac)\/+[^/]+\/+(?<asin>B[\dA-Z]{9}|\d{9}(?:X|\d))\b/
+        /^https:\/\/(?:www\.)?audible\.[a-z.]+\/+(?:pd|p|ac)\/+[^/]+\/+(?<asin>B[\dA-Z]{9}|\d{9}(?:X|\d))\b/i
     ];
 
-    async getDetails() {
-        return getAudibleDetails();
+    /**
+     * Parse an ASIN identifier from Audible URLs.
+     *
+     * @param {string | null | undefined} url URL that may contain an ASIN.
+     * @returns {string | null} Parsed ASIN in uppercase, or null if none found.
+     */
+    extractAsinFromUrl(url) {
+        if (!url) return null;
+        const match = url.match(this._sitePatterns[0])?.groups?.asin || url.match(/asin=([A-Z0-9]{10})/i)?.[1];
+        return match?.toUpperCase() ?? null;
     }
-}
 
-async function getAudibleDetails() {
-    const details = {};
-
-    try {
-        const asin = extractAsinFromUrl(window.location.href);
+    async getDetails() {
+        const details = {};
+        const asin = this.extractAsinFromUrl(window.location.href);
 
         if (!asin) {
             logMarian('Audible extraction failed: No ASIN found in URL');
@@ -58,9 +63,6 @@ async function getAudibleDetails() {
         delete details.Version;
 
         logMarian('Audible extraction complete', details);
-        return details;
-    } catch (e) {
-        logMarian('Audible extraction failed', { error: String(e) });
         return details;
     }
 }
@@ -278,18 +280,6 @@ export async function fetchAudibleApiDetails(asin, tld = null) {
     // }
 
     return details;
-}
-
-/**
- * Parse an ASIN identifier from Audible URLs.
- *
- * @param {string | null | undefined} url URL that may contain an ASIN.
- * @returns {string | null} Parsed ASIN in uppercase, or null if none found.
- */
-function extractAsinFromUrl(url) {
-    if (!url) return null;
-    const match = url.match(/\/(?:pd|p)\/[^/]+\/([A-Z0-9]{10})(?:[/?]|$)/i) || url.match(/asin=([A-Z0-9]{10})/i);
-    return match ? match[1].toUpperCase() : null;
 }
 
 export { audibleScraper };

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -101,6 +101,8 @@ export async function fetchAudnexusApiDetails(asin, region = null) {
         region = getRegion(tld);
     }
 
+    details["Audible Region"] = region;
+
     let data;
 
     try {
@@ -190,6 +192,8 @@ export async function fetchAudibleApiDetails(asin, tld = null) {
 
     if (!tld.startsWith(".")) tld = `.${tld}`;
     const apiHost = `api.audible${tld}`;
+
+    details["Audible Region"] = getRegion(tld);
 
     try {
         resHtml = await fetchBackground(`https://${apiHost}/1.0/catalog/products/${asin}?response_groups=category_ladders,contributors,media,product_attrs,product_desc,product_details,product_extended_attrs,rating,series&image_sizes=512,1024`);

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -1,381 +1,574 @@
-import { Extractor } from './AbstractExtractor.js';
 import {
-  getImageScore,
-  logMarian,
-  getFormattedText,
-  queryAllDeep,
-  queryDeep,
-  clearDeepQueryCache,
-  withTimeout,
-  cleanText,
+    cleanText,
+    clearDeepQueryCache,
+    getFormattedText,
+    getImageScore,
+    logMarian,
+    queryAllDeep,
+    queryDeep,
+    withTimeout,
 } from '../shared/utils.js';
+import { Extractor } from './AbstractExtractor.js';
 
 const DEBUG = false;
 
 // Known shadow-hosts / component surfaces to search
 // Audible uses a lot of web components
 const KNOWN_DEEP_HOSTS = [
-  'adbl-product-details',
-  'adbl-product-metadata',
-  'adbl-title-lockup',
-  'adbl-product-hero',
-  'adbl-product-image',
-  '[data-automation-id="titleSubtitle"]',
-  '[data-automation-id="hero-metadata"]',
-  '[data-automation-id="hero-art"]',
+    'adbl-product-details',
+    'adbl-product-metadata',
+    'adbl-title-lockup',
+    'adbl-product-hero',
+    'adbl-product-image',
+    '[data-automation-id="titleSubtitle"]',
+    '[data-automation-id="hero-metadata"]',
+    '[data-automation-id="hero-art"]',
 ];
 
 class audibleScraper extends Extractor {
-  get _name() { return "Audible Extractor"; }
-  _sitePatterns = [
-    /^https?:\/\/(www\.)?audible\.[a-z.]+\/pd\/(?:[^/]+\/)*[A-Z0-9]{10}(?:\?.*)?$/,
-  ];
+    get _name() { return "Audible Extractor"; }
+    _sitePatterns = [
+        /^https?:\/\/(www\.)?audible\.[a-z.]+\/pd\/(?:[^/]+\/)*[A-Z0-9]{10}(?:\?.*)?$/,
+    ];
 
-  async getDetails() {
-    return getAudibleDetails();
-  }
+    async getDetails() {
+        return getAudibleDetails();
+    }
 }
 
 async function getAudibleDetails() {
-  clearDeepQueryCache();
-  const details = {};
-  const asyncJobs = [];
+    clearDeepQueryCache();
+    const details = {};
+    const asyncJobs = [];
 
-  try {
-    const cover = getPrimaryImage();
-    if (cover?.src) {
-      const src = cover.src;
-      details.img = src;
-      asyncJobs.push(
-        withTimeout(getImageScore(src), 1500, 0)
-          .then(s => { details.imgScore = s; })
-          .catch(e => { details.imgScore = 0; })
-      );
-    } else {
-      details.imgScore = 0;
+    try {
+        const asin = extractAsinFromUrl(window.location.href);
+
+        if (asin) {
+            details.ASIN = asin;
+            // Try to fetch data from Audible API
+            try {
+                const audnexusData = await fetchAudnexusApiDetails(asin);
+                if (audnexusData && Object.keys(audnexusData).length > 0) {
+                    Object.assign(details, audnexusData);
+                    logMarian('Audnexus extraction complete', audnexusData);
+                } else {
+                    const audibleData = await fetchAudibleApiDetails(asin);
+                    if (audibleData && Object.keys(audibleData).length > 0) {
+                        Object.assign(details, audibleData);
+                        logMarian('Audible API extraction complete', audibleData);
+                    }
+                }
+            } catch (err) {
+                logMarian('Audible API extraction failed, falling back to DOM scraping', err);
+            }
+        }
+
+        // Only fallback to DOM scraping for fields not already extracted
+        const cover = getPrimaryImage();
+        if (!details.img && cover?.src) {
+            const src = cover.src;
+            details.img = src;
+            asyncJobs.push(
+                withTimeout(getImageScore(src), 1500, 0)
+                    .then(s => { details.imgScore = s; })
+                    .catch(e => { details.imgScore = 0; })
+            );
+        } else if (details.img && details.imgScore === undefined) {
+            asyncJobs.push(
+                withTimeout(getImageScore(details.img), 1500, 0)
+                    .then(s => { details.imgScore = s; })
+                    .catch(e => { details.imgScore = 0; })
+            );
+        }
+
+        if (!details.Title) {
+            const title = getFirstText([
+                '[data-automation-id="adbl-product-title"]',
+                'adbl-title-lockup [slot="title"]',
+                'adbl-product-hero [slot="title"]',
+                'meta[property="og:title"]',
+                'title',
+            ]);
+            if (title) details.Title = title;
+        }
+
+        if (!details.Description) {
+            const description = getDescription();
+            if (description) details.Description = description;
+        }
+
+        // Collect DOM metadata but prefer API data
+        const domMetadata = collectMetadata();
+        for (const [key, value] of Object.entries(domMetadata)) {
+            if (!details[key]) {
+                details[key] = value;
+            }
+        }
+
+        if (!details['Reading Format']) details['Reading Format'] = 'Audiobook';
+        if (!details['Edition Format'] && details['Reading Format']) {
+            details['Edition Format'] = details['Reading Format'];
+        }
+
+        delete details.Edition;
+        delete details.Version;
+
+        await Promise.allSettled(asyncJobs);
+
+        logMarian('Audible extraction complete', details);
+        return details;
+    } catch (e) {
+        logMarian('Audible extraction failed', { error: String(e) });
+        return details;
     }
-
-    const title = getFirstText([
-      '[data-automation-id="adbl-product-title"]',
-      'adbl-title-lockup [slot="title"]',
-      'adbl-product-hero [slot="title"]',
-      'meta[property="og:title"]',
-      'title',
-    ]);
-    if (title) details.Title = title;
-
-    const description = getDescription();
-    if (description) details.Description = description;
-
-    Object.assign(details, collectMetadata());
-
-    // This is audible's ASIN, does not match amazon retail's ASIN
-    if (!details.ASIN) {
-      const asin = extractAsinFromUrl(window.location.href);
-      if (asin) details.ASIN = asin;
-    }
-
-    if (!details['Reading Format']) details['Reading Format'] = 'Audiobook';
-    if (!details['Edition Format'] && details['Reading Format']) {
-      details['Edition Format'] = details['Reading Format'];
-    }
-
-    delete details.Edition;
-    delete details.Version;
-
-    await Promise.allSettled(asyncJobs);
-
-    logMarian('Audible extraction complete', details);
-    return details;
-  } catch (e) {
-    logMarian('Audible extraction failed', { error: String(e) });
-    return details;
-  }
 }
 
 function collectMetadata() {
-  const contributorMap = new Map();
-  const fields = {};
-  // Collect data from product metadata, product details, and hero from DOM
-  const pairs = [
-    ...collectListPairs(),
-    ...collectMetadataLines(),
-    ...collectTablePairs(),
-  ];
+    const contributorMap = new Map();
+    const fields = {};
+    // Collect data from product metadata, product details, and hero from DOM
+    const pairs = [
+        ...collectListPairs(),
+        ...collectMetadataLines(),
+        ...collectTablePairs(),
+    ];
 
-  // Figure out how they map to the values we show in the UI
-  pairs.forEach(({ label, values }) => applyPair(fields, contributorMap, label, values));
+    // Figure out how they map to the values we show in the UI
+    for (const { label, values } of pairs) {
+        applyPair(fields, contributorMap, label, values);
+    }
 
-  // Serialize all of the contributors found
-  const contributors = Array.from(contributorMap.entries()).map(([name, roles]) => ({
-    name,
-    roles: Array.from(roles),
-  }));
-  if (contributors.length) fields.Contributors = contributors;
-  return fields;
+    // Serialize all of the contributors found
+    const contributors = Array.from(contributorMap.entries()).map(([name, roles]) => ({
+        name,
+        roles: Array.from(roles),
+    }));
+    if (contributors.length) fields.Contributors = contributors;
+    return fields;
 }
 
 function collectListPairs() {
-  // Hero subtitle list renders as free text ("Label: value") inside shadow roots
-  return queryAllDeep('[data-automation-id="hero-metadata"] li.bc-list-item, [data-automation-id="titleSubtitle"] li.bc-list-item', KNOWN_DEEP_HOSTS)
-    .map(node => cleanText(node.textContent))
-    .filter(Boolean)
-    .map(text => {
-      const match = text.match(/^([^:]+):\s*(.+)$/); // "Label: Value" pair
-      if (!match) return null;
-      return { label: match[1], values: cleanValues([match[2]]) };
-    })
-    .filter(Boolean);
+    // Hero subtitle list renders as free text ("Label: value") inside shadow roots
+    return queryAllDeep('[data-automation-id="hero-metadata"] li.bc-list-item, [data-automation-id="titleSubtitle"] li.bc-list-item', KNOWN_DEEP_HOSTS)
+        .map(node => cleanText(node.textContent))
+        .filter(Boolean)
+        .map(text => {
+            const match = text.match(/^([^:]+):\s*(.+)$/); // "Label: Value" pair
+            if (!match) return null;
+            return { label: match[1], values: cleanValues([match[2]]) };
+        })
+        .filter(Boolean);
+}
+
+async function fetchAudnexusApiDetails(asin) {
+    const details = {};
+    let region = 'us';
+    if (window.location.host.includes('.ca')) region = 'ca';
+    else if (window.location.host.includes('.co.uk')) region = 'uk';
+    else if (window.location.host.includes('.com.au')) region = 'au';
+    else if (window.location.host.includes('.fr')) region = 'fr';
+    else if (window.location.host.includes('.de')) region = 'de';
+    else if (window.location.host.includes('.it')) region = 'it';
+    else if (window.location.host.includes('.es')) region = 'es';
+    else if (window.location.host.includes('.in')) region = 'in';
+    else if (window.location.host.includes('.co.jp')) region = 'jp';
+
+    const res = await fetch(`https://api.audnex.us/books/${asin}?region=${region}`);
+    if (!res.ok) return details;
+    const data = await res.json();
+
+    if (data.title) details.Title = data.title + (data.subtitle ? `: ${data.subtitle}` : '');
+    if (data.summary) {
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = data.summary;
+        details.Description = getFormattedText(tempDiv);
+    }
+    if (data.image) details.img = data.image;
+    if (data.publisherName) details.Publisher = cleanText(data.publisherName);
+    if (data.releaseDate) details['Publication date'] = new Date(data.releaseDate).toISOString().split('T')[0];
+    if (data.language) details.Language = data.language;
+    if (data.isbn) details['ISBN-13'] = data.isbn;
+
+    const contributors = [];
+    if (data.authors) {
+        for (const a of data.authors) {
+            contributors.push({ name: cleanText(a.name), roles: ['Author'] });
+        }
+    }
+    if (data.narrators) {
+        for (const n of data.narrators) {
+            contributors.push({ name: cleanText(n.name), roles: ['Narrator'] });
+        }
+    }
+    if (contributors.length) details.Contributors = contributors;
+
+    if (data.seriesPrimary) {
+        if (data.seriesPrimary.name) details.Series = cleanText(data.seriesPrimary.name);
+        if (data.seriesPrimary.position) details['Series Place'] = data.seriesPrimary.position;
+    }
+
+    const lengthMin = data.runtimeLengthMin || 0;
+    if (lengthMin) {
+        const hours = Math.floor(lengthMin / 60);
+        const mins = lengthMin % 60;
+        const lengthArr = [];
+        if (hours > 0) lengthArr.push(`${hours} hours`);
+        if (mins > 0) lengthArr.push(`${mins} minutes`);
+        details['Listening Length'] = lengthArr;
+    }
+
+    if (data.formatType) {
+        if (data.formatType.toLowerCase() === 'unabridged') {
+            details['Edition Information'] = 'Unabridged';
+        } else if (data.formatType.toLowerCase() === 'abridged') {
+            details['Edition Information'] = 'Abridged';
+        }
+    }
+    details['Edition Format'] = 'Audible';
+
+    if (data.genres) {
+        details.Categories = data.genres.map(g => cleanText(g.name));
+    }
+
+    if (data.rating && +data.rating != 0) {
+        details['Average Rating'] = parseFloat(data.rating);
+    }
+
+    return details;
+}
+
+async function fetchAudibleApiDetails(asin) {
+    const details = {};
+    const res = await fetch(`https://api.audible.com/1.0/catalog/products/${asin}?response_groups=category_ladders,contributors,media,product_attrs,product_desc,product_details,product_extended_attrs,rating,series&image_sizes=512,1024`);
+    if (!res.ok) return details;
+    const json = await res.json();
+    const data = json.product;
+    if (!data) return details;
+
+    if (data.title) details.Title = data.title + (data.subtitle ? `: ${data.subtitle}` : '');
+    if (data.publisher_summary) {
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = data.publisher_summary;
+        details.Description = getFormattedText(tempDiv);
+    }
+
+    if (data.product_images && data.product_images['1024']) {
+        details.img = data.product_images['1024'];
+    }
+
+    if (data.publisher_name) details.Publisher = cleanText(data.publisher_name);
+    if (data.release_date) details['Publication date'] = data.release_date;
+    if (data.language) details.Language = data.language;
+    if (data.isbn) details['ISBN-13'] = data.isbn;
+
+    const contributors = [];
+    if (data.authors) {
+        for (const a of data.authors) {
+            contributors.push({ name: cleanText(a.name), roles: ['Author'] });
+        }
+    }
+    if (data.narrators) {
+        for (const n of data.narrators) {
+            contributors.push({ name: cleanText(n.name), roles: ['Narrator'] });
+        }
+    }
+    if (contributors.length) details.Contributors = contributors;
+
+    if (data.series && data.series.length > 0) {
+        const primary = data.series[0];
+        if (primary.title) details.Series = cleanText(primary.title);
+        if (primary.sequence) details['Series Place'] = primary.sequence;
+    }
+
+    const lengthMin = data.runtime_length_min || 0;
+    if (lengthMin) {
+        const hours = Math.floor(lengthMin / 60);
+        const mins = lengthMin % 60;
+        const lengthArr = [];
+        if (hours > 0) lengthArr.push(`${hours} hours`);
+        if (mins > 0) lengthArr.push(`${mins} minutes`);
+        details['Listening Length'] = lengthArr;
+    }
+
+    if (data.format_type) {
+        if (data.format_type.toLowerCase() === 'unabridged') {
+            details['Edition Information'] = 'Unabridged';
+        } else if (data.format_type.toLowerCase() === 'abridged') {
+            details['Edition Information'] = 'Abridged';
+        }
+    }
+    details['Edition Format'] = 'Audible';
+
+    if (data.category_ladders) {
+        const categories = new Set();
+        for (const ladder of data.category_ladders) {
+            if (ladder.ladder) {
+                for (const item of ladder.ladder) {
+                    if (item.name) categories.add(cleanText(item.name));
+                }
+            }
+        }
+        if (categories.size > 0) {
+            details.Categories = Array.from(categories);
+        }
+    }
+
+    return details;
 }
 
 function collectMetadataLines() {
-  const pairs = [];
-  queryAllDeep('adbl-product-metadata', KNOWN_DEEP_HOSTS).forEach(host => {
-    const root = host.shadowRoot || host;
-    // Each metadata line exposes optional label/value slots per locale variant
-    const lines = root?.querySelectorAll?.('.line[role="group"], [data-automation-id="metadata-line"]');
-    lines?.forEach(line => {
-      const labelEl = line.querySelector('.label, [slot="label"], [data-automation-id="metadata-label"], dt');
-      const label = cleanText(labelEl?.textContent || line.getAttribute('key'));
-      if (!label) return;
-      const valueNodes = line.querySelectorAll('.values a, .values .text, .values span, [slot="values"] *, [data-automation-id="metadata-value"] *, dd, .value');
-      const values = cleanValues(
-        valueNodes.length ? Array.from(valueNodes, node => node.textContent) : [line.textContent]
-      );
-      if (values.length) pairs.push({ label, values });
+    const pairs = [];
+    queryAllDeep('adbl-product-metadata', KNOWN_DEEP_HOSTS).forEach(host => {
+        const root = host.shadowRoot || host;
+        // Each metadata line exposes optional label/value slots per locale variant
+        const lines = root?.querySelectorAll?.('.line[role="group"], [data-automation-id="metadata-line"]');
+        if (!lines) return;
+
+        for (const line of lines) {
+            const labelEl = line.querySelector('.label, [slot="label"], [data-automation-id="metadata-label"], dt');
+            const label = cleanText(labelEl?.textContent || line.getAttribute('key'));
+            if (!label) continue;
+            const valueNodes = line.querySelectorAll('.values a, .values .text, .values span, [slot="values"] *, [data-automation-id="metadata-value"] *, dd, .value');
+            const values = cleanValues(
+                valueNodes.length ? Array.from(valueNodes, node => node.textContent) : [line.textContent]
+            );
+            if (values.length) pairs.push({ label, values });
+        }
     });
-  });
-  return pairs;
+    return pairs;
 }
 
 function collectTablePairs() {
-  const rows = document.querySelectorAll('#audibleProductDetails table tr, #productDetails table tr');
-  const pairs = [];
-  rows.forEach(row => {
-    const label = cleanText(row.querySelector('th, td:first-child')?.textContent);
-    const value = cleanText(row.querySelector('td:last-child')?.textContent);
-    if (label && value) pairs.push({ label, values: [value] });
-  });
-  return pairs;
+    const rows = document.querySelectorAll('#audibleProductDetails table tr, #productDetails table tr');
+    const pairs = [];
+    for (const row of rows) {
+        const label = cleanText(row.querySelector('th, td:first-child')?.textContent);
+        const value = cleanText(row.querySelector('td:last-child')?.textContent);
+        if (label && value) pairs.push({ label, values: [value] });
+    }
+    return pairs;
 }
 
 function applyPair(fields, contributors, label, rawValues) {
-  const normalized = normalizeLabel(label);
-  const values = cleanValues(rawValues);
-  if (!normalized || !values.length) return;
+    const normalized = normalizeLabel(label);
+    const values = cleanValues(rawValues);
+    if (!normalized || !values.length) return;
 
-  let handled = true;
+    let handled = true;
 
-  switch (normalized) {
-    case 'by':
-    case 'written by':
-    case 'author':
-    case 'authors':
-      addContributors(contributors, values, 'Author');
-      break;
-    case 'narrated by':
-    case 'narrator':
-    case 'narrators':
-      addContributors(contributors, values, 'Narrator');
-      break;
-    case 'performed by':
-    case 'performed':
-      addContributors(contributors, values, 'Narrator');
-      break;
-    case 'directed by':
-      addContributors(contributors, values, 'Director');
-      break;
-    case 'translated by':
-    case 'translator':
-      addContributors(contributors, values, 'Translator');
-      break;
-    case 'composer':
-      addContributors(contributors, values, 'Composer');
-      break;
-    case 'publisher':
-      setField(fields, 'Publisher', values.join(', '));
-      break;
-    case 'language':
-      setField(fields, 'Language', values.join(', '));
-      break;
-    case 'length':
-    case 'listening length':
-    case 'runtime':
-    case 'runtime length':
-    case 'audio length':
-      setField(fields, 'Listening Length', parseListeningLength(values[0]));
-      break;
-    case 'release date':
-    case 'publication date':
-    case 'audible release date':
-    case 'audible.com release date':
-    case 'audible com release date':
-      setField(fields, 'Publication date', values[0]);
-      break;
-    case 'program type':
-      applyProgramType(fields, values[0]);
-      break;
-    case 'format':
-    case 'edition':
-      fields['Edition Format'] ??= values[0];
-      break;
-    case 'version':
-      setField(fields, 'Edition Information', values[0]);
-      break;
-    case 'series':
-      values.forEach(value => applySeries(fields, value));
-      break;
-    case 'series number':
-    case 'series place':
-      setField(fields, 'Series Place', values[0]);
-      break;
-    case 'asin':
-      fields.ASIN ??= values[0];
-      break;
-    default:
-      handled = false;
-      if (DEBUG) logMarian('Unhandled label', { label, normalized, values });
-      break;
-  }
+    switch (normalized) {
+        case 'by':
+        case 'written by':
+        case 'author':
+        case 'authors':
+            addContributors(contributors, values, 'Author');
+            break;
+        case 'narrated by':
+        case 'narrator':
+        case 'narrators':
+            addContributors(contributors, values, 'Narrator');
+            break;
+        case 'performed by':
+        case 'performed':
+            addContributors(contributors, values, 'Narrator');
+            break;
+        case 'directed by':
+            addContributors(contributors, values, 'Director');
+            break;
+        case 'translated by':
+        case 'translator':
+            addContributors(contributors, values, 'Translator');
+            break;
+        case 'composer':
+            addContributors(contributors, values, 'Composer');
+            break;
+        case 'publisher':
+            setField(fields, 'Publisher', values.join(', '));
+            break;
+        case 'language':
+            setField(fields, 'Language', values.join(', '));
+            break;
+        case 'length':
+        case 'listening length':
+        case 'runtime':
+        case 'runtime length':
+        case 'audio length':
+            setField(fields, 'Listening Length', parseListeningLength(values[0]));
+            break;
+        case 'release date':
+        case 'publication date':
+        case 'audible release date':
+        case 'audible.com release date':
+        case 'audible com release date':
+            setField(fields, 'Publication date', values[0]);
+            break;
+        case 'program type':
+            applyProgramType(fields, values[0]);
+            break;
+        case 'format':
+        case 'edition':
+            fields['Edition Format'] ??= values[0];
+            break;
+        case 'version':
+            setField(fields, 'Edition Information', values[0]);
+            break;
+        case 'series':
+            for (const value of values) {
+                applySeries(fields, value);
+            }
+            break;
+        case 'series number':
+        case 'series place':
+            setField(fields, 'Series Place', values[0]);
+            break;
+        case 'asin':
+            fields.ASIN ??= values[0];
+            break;
+        default:
+            handled = false;
+            if (DEBUG) logMarian('Unhandled label', { label, normalized, values });
+            break;
+    }
 
 }
 
 function addContributors(map, values, role) {
-  values.flatMap(splitContributorNames).forEach(name => {
-    if (!name) return;
-    const roles = map.get(name) || new Set();
-    roles.add(role);
-    map.set(name, roles);
-  });
+    for (const name of values.flatMap(splitContributorNames)) {
+        if (!name) continue;
+        const roles = map.get(name) || new Set();
+        roles.add(role);
+        map.set(name, roles);
+    }
 }
 
 function splitContributorNames(value) {
-  const chunks = value
-    .split(/\s+(?:and|&)\s+/i) // Split between "and" and "&"
-    .map(cleanText)
-    .filter(Boolean);
-  const out = [];
-  for (const chunk of chunks) {
-    if (/,.*,.*/.test(chunk)) { // Check for two commas
-      // Likely "A, B, C" list
-      out.push(...chunk.split(/\s*,\s*/).map(cleanText).filter(Boolean)); // Split on commas
-    } else {
-      out.push(chunk);
+    const chunks = value
+        .split(/\s+(?:and|&)\s+/i) // Split between "and" and "&"
+        .map(cleanText)
+        .filter(Boolean);
+    const out = [];
+    for (const chunk of chunks) {
+        if (/,.*,.*/.test(chunk)) { // Check for two commas
+            // Likely "A, B, C" list
+            out.push(...chunk.split(/\s*,\s*/).map(cleanText).filter(Boolean)); // Split on commas
+        } else {
+            out.push(chunk);
+        }
     }
-  }
-  return out;
+    return out;
 }
 
 function setField(fields, key, value) {
-  if (!value || fields[key]) return;
-  if (Array.isArray(value) && !value.length) return;
-  fields[key] = value;
+    if (!value || fields[key]) return;
+    if (Array.isArray(value) && !value.length) return;
+    fields[key] = value;
 }
 
 function applyProgramType(fields, value) {
-  if (!value) return;
-  const lower = value.toLowerCase();
-  if (lower.includes('podcast')) {
-    setField(fields, 'Reading Format', 'Podcast');
-  } else if (lower.includes('audio')) {
-    setField(fields, 'Reading Format', 'Audiobook');
-  } else {
-    setField(fields, 'Reading Format', value);
-  }
-  fields['Edition Format'] ??= value;
+    if (!value) return;
+    const lower = value.toLowerCase();
+    if (lower.includes('podcast')) {
+        setField(fields, 'Reading Format', 'Podcast');
+    } else if (lower.includes('audio')) {
+        setField(fields, 'Reading Format', 'Audiobook');
+    } else {
+        setField(fields, 'Reading Format', value);
+    }
+    fields['Edition Format'] ??= value;
 }
 
 function applySeries(fields, value) {
-  const text = cleanText(value);
-  if (!text) return;
-  const position = parseSeriesPlace(text);
-  // remove patterns like ", Book 3", "Vol. 2", "#1.5" etc. at the end
-  const SERIES_TRAIL = /(?:,?\s*(?:Book|Volume|Vol\.?|Part)\s*\d+(?:\.\d+)?|#\s*\d+(?:\.\d+)?)\s*$/i;
-  // remove patterns like "Book 2: " or "Vol. 3 - " at the beginning
-  const SERIES_LEAD = /^(?:Book|Volume|Vol\.?|Part|#)\s*\d+(?:\.\d+)?\s*[:,\-\u2013]\s*/i;
-  // remove trailing parentheses like "(Book 2)" at the end
-  const SERIES_PAREN = /\(\s*(?:Book|Volume|Vol\.?|Part|#)\s*\d+(?:\.\d+)?\s*\)\s*$/i;
+    const text = cleanText(value);
+    if (!text) return;
+    const position = parseSeriesPlace(text);
+    // remove patterns like ", Book 3", "Vol. 2", "#1.5" etc. at the end
+    const SERIES_TRAIL = /(?:,?\s*(?:Book|Volume|Vol\.?|Part)\s*\d+(?:\.\d+)?|#\s*\d+(?:\.\d+)?)\s*$/i;
+    // remove patterns like "Book 2: " or "Vol. 3 - " at the beginning
+    const SERIES_LEAD = /^(?:Book|Volume|Vol\.?|Part|#)\s*\d+(?:\.\d+)?\s*[:,\-\u2013]\s*/i;
+    // remove trailing parentheses like "(Book 2)" at the end
+    const SERIES_PAREN = /\(\s*(?:Book|Volume|Vol\.?|Part|#)\s*\d+(?:\.\d+)?\s*\)\s*$/i;
 
-  let name = text
-    .replace(SERIES_TRAIL, '')
-    .replace(SERIES_LEAD, '')
-    .replace(SERIES_PAREN, '');
-  name = name.replace(/^[\s,:-]+|[\s,:-]+$/g, '').trim();
-  if (name) setField(fields, 'Series', name);
-  if (position) setField(fields, 'Series Place', position);
+    let name = text
+        .replace(SERIES_TRAIL, '')
+        .replace(SERIES_LEAD, '')
+        .replace(SERIES_PAREN, '');
+    name = name.replace(/^[\s,:-]+|[\s,:-]+$/g, '').trim();
+    if (name) setField(fields, 'Series', name);
+    if (position) setField(fields, 'Series Place', position);
 }
 
 function parseSeriesPlace(value) {
-  // Extracts a number after keywords like “Book” or “#”
-  const match = value.match(/(?:Book|Volume|Vol\.?|Part|#)\s*(\d+(?:\.\d+)?)/i);
-  return match ? match[1] : null;
+    // Extracts a number after keywords like “Book” or “#”
+    const match = value.match(/(?:Book|Volume|Vol\.?|Part|#)\s*(\d+(?:\.\d+)?)/i);
+    return match ? match[1] : null;
 }
 
 function parseListeningLength(value) {
-  if (!value) return value;
-  const text = cleanText(Array.isArray(value) ? value.join(' ') : value);
-  const hours = +(text.match(/(\d+)\s*(?:hours?|hrs?)/i)?.[1] || 0);
-  const minutes = +(text.match(/(\d+)\s*(?:minutes?|mins?)/i)?.[1] || 0);
-  const seconds = +(text.match(/(\d+)\s*(?:seconds?|secs?)/i)?.[1] || 0);
-  const parts = [];
-  if (hours) parts.push(`${hours} hours`);
-  if (minutes) parts.push(`${minutes} minutes`);
-  if (seconds) parts.push(`${seconds} seconds`);
-  return parts.length ? parts : text;
+    if (!value) return value;
+    const text = cleanText(Array.isArray(value) ? value.join(' ') : value);
+    const hours = +(text.match(/(\d+)\s*(?:hours?|hrs?)/i)?.[1] || 0);
+    const minutes = +(text.match(/(\d+)\s*(?:minutes?|mins?)/i)?.[1] || 0);
+    const seconds = +(text.match(/(\d+)\s*(?:seconds?|secs?)/i)?.[1] || 0);
+    const parts = [];
+    if (hours) parts.push(`${hours} hours`);
+    if (minutes) parts.push(`${minutes} minutes`);
+    if (seconds) parts.push(`${seconds} seconds`);
+    return parts.length ? parts : text;
 }
 
 function getDescription() {
-  const selectors = [
-    'adbl-product-details [slot="summary"]',
-    'adbl-product-details adbl-text-block[slot="summary"]',
-    '[data-automation-id="productDescription"]',
-    '[data-automation-id="adbl-product-description"]',
-    '#publisher-summary',
-    '#publisher-s-summary',
-    '#product-description',
-  ];
+    const selectors = [
+        'adbl-product-details [slot="summary"]',
+        'adbl-product-details adbl-text-block[slot="summary"]',
+        '[data-automation-id="productDescription"]',
+        '[data-automation-id="adbl-product-description"]',
+        '#publisher-summary',
+        '#publisher-s-summary',
+        '#product-description',
+    ];
 
-  for (const selector of selectors) {
-    const el = queryDeep(selector, KNOWN_DEEP_HOSTS);
-    if (!el) continue;
-    const text = getFormattedText(el);
-    if (text) return text;
-  }
+    for (const selector of selectors) {
+        const el = queryDeep(selector, KNOWN_DEEP_HOSTS);
+        if (!el) continue;
+        const text = getFormattedText(el);
+        if (text) return text;
+    }
 
-  const meta = document.querySelector('meta[name="description"]')?.getAttribute('content');
-  return cleanText(meta);
+    const meta = document.querySelector('meta[name="description"]')?.getAttribute('content');
+    return cleanText(meta);
 }
 
 function getPrimaryImage() {
-  return (
-    queryDeep('.adbl-product-image img', KNOWN_DEEP_HOSTS) ||
-    queryDeep('[data-automation-id="hero-art"] img', KNOWN_DEEP_HOSTS) ||
-    queryDeep('img.bc-pub-media', KNOWN_DEEP_HOSTS) ||
-    document.querySelector('img[alt*="cover art" i]') ||
-    document.querySelector('img[alt*="portada" i]')
-  );
+    return (
+        queryDeep('.adbl-product-image img', KNOWN_DEEP_HOSTS) ||
+        queryDeep('[data-automation-id="hero-art"] img', KNOWN_DEEP_HOSTS) ||
+        queryDeep('img.bc-pub-media', KNOWN_DEEP_HOSTS) ||
+        document.querySelector('img[alt*="cover art" i]') ||
+        document.querySelector('img[alt*="portada" i]')
+    );
 }
 
 function getFirstText(selectors) {
-  for (const selector of selectors) {
-    if (selector === 'title') {
-      const text = cleanText(document.title);
-      if (text) return text;
-      continue;
-    }
+    for (const selector of selectors) {
+        if (selector === 'title') {
+            const text = cleanText(document.title);
+            if (text) return text;
+            continue;
+        }
 
-    if (selector.startsWith('meta[')) {
-      const meta = document.querySelector(selector);
-      const content = cleanText(meta?.getAttribute('content'));
-      if (content) return content;
-      continue;
-    }
+        if (selector.startsWith('meta[')) {
+            const meta = document.querySelector(selector);
+            const content = cleanText(meta?.getAttribute('content'));
+            if (content) return content;
+            continue;
+        }
 
-    const el = queryDeep(selector, KNOWN_DEEP_HOSTS);
-    const text = cleanText(el?.textContent);
-    if (text) return text;
-  }
-  return null;
+        const el = queryDeep(selector, KNOWN_DEEP_HOSTS);
+        const text = cleanText(el?.textContent);
+        if (text) return text;
+    }
+    return null;
 }
 
 /**
@@ -385,24 +578,24 @@ function getFirstText(selectors) {
  * @returns {string[]} Unique sanitized values.
  */
 function cleanValues(values) {
-  const seen = new Set();
-  const result = [];
+    const seen = new Set();
+    const result = [];
 
-  values
-    .filter(Boolean)
-    .map(cleanText)
-    .forEach(value => {
-      if (!value) return;
-      value.split(/\s*\|\s*/).forEach(part => {
-        const piece = cleanText(part);
-        if (piece && !seen.has(piece)) {
-          seen.add(piece);
-          result.push(piece);
+    for (const value of values) {
+        if (!value) continue;
+        const cleaned = cleanText(value);
+        if (!cleaned) continue;
+
+        for (const part of cleaned.split(/\s*\|\s*/)) {
+            const piece = cleanText(part);
+            if (piece && !seen.has(piece)) {
+                seen.add(piece);
+                result.push(piece);
+            }
         }
-      });
-    });
+    }
 
-  return result;
+    return result;
 }
 
 /**
@@ -412,7 +605,7 @@ function cleanValues(values) {
  * @returns {string} Lowercase sanitized label.
  */
 function normalizeLabel(label) {
-  return cleanText(label).toLowerCase();
+    return cleanText(label).toLowerCase();
 }
 
 /**
@@ -422,9 +615,9 @@ function normalizeLabel(label) {
  * @returns {string | null} Parsed ASIN in uppercase, or null if none found.
  */
 function extractAsinFromUrl(url) {
-  if (!url) return null;
-  const match = url.match(/\/(?:pd|p)\/[^/]+\/([A-Z0-9]{10})(?:[/?]|$)/i) || url.match(/asin=([A-Z0-9]{10})/i);
-  return match ? match[1].toUpperCase() : null;
+    if (!url) return null;
+    const match = url.match(/\/(?:pd|p)\/[^/]+\/([A-Z0-9]{10})(?:[/?]|$)/i) || url.match(/asin=([A-Z0-9]{10})/i);
+    return match ? match[1].toUpperCase() : null;
 }
 
 export { audibleScraper };

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -99,9 +99,18 @@ export async function fetchAudnexusApiDetails(asin, region = null) {
         region = getRegion(tld);
     }
 
-    const resHtml = await fetchBackground(`https://api.audnex.us/books/${asin}?region=${region}`);
-    if (!resHtml) return details;
-    const data = JSON.parse(resHtml);
+    let data;
+
+    try {
+        const resHtml = await fetchBackground(`https://api.audnex.us/books/${asin}?region=${region}`);
+        if (!resHtml) return details;
+        data = JSON.parse(resHtml);
+        if (!data) return details;
+    } catch {
+        if (e.message?.startsWith('MISSING_PERMISSION:')) throw e;
+        logMarian("Audnexus fetch failed", e);
+        return details;
+    }
 
     if (data.title) details.Title = data.title + (data.subtitle ? `: ${data.subtitle}` : '');
     if (data.summary) {
@@ -169,7 +178,7 @@ export async function fetchAudnexusApiDetails(asin, region = null) {
  */
 export async function fetchAudibleApiDetails(asin, tld = null) {
     const details = {};
-    let resHtml;
+    let data;
 
     if (tld == null) {
         if (!window.location.host.includes('audible.')) throw new Error("Must provide tld");
@@ -182,14 +191,15 @@ export async function fetchAudibleApiDetails(asin, tld = null) {
 
     try {
         resHtml = await fetchBackground(`https://${apiHost}/1.0/catalog/products/${asin}?response_groups=category_ladders,contributors,media,product_attrs,product_desc,product_details,product_extended_attrs,rating,series&image_sizes=512,1024`);
+
+        if (!resHtml) return details;
+        const json = JSON.parse(resHtml);
+        data = json.product;
+        if (!data) return details;
     } catch (e) {
         if (e.message?.startsWith('MISSING_PERMISSION:')) throw e;
         return details;
     }
-    if (!resHtml) return details;
-    const json = JSON.parse(resHtml);
-    const data = json.product;
-    if (!data) return details;
 
     if (data.title) details.Title = data.title + (data.subtitle ? `: ${data.subtitle}` : '');
     if (data.publisher_summary) {

--- a/src/extractors/dnbde.js
+++ b/src/extractors/dnbde.js
@@ -1,8 +1,8 @@
 import { Extractor } from './AbstractExtractor.js';
 import {
-  logMarian, runtime, getFormattedText, getCoverData, remapKeys,
-  addContributor, cleanText,
-  collectObject
+  addContributor, cleanText, collectObject,
+  fetchBackground, getCoverData, getFormattedText,
+  logMarian, remapKeys
 } from '../shared/utils.js';
 
 const remapings = {
@@ -70,7 +70,7 @@ function extractTable(/**@type{HTMLTableElement}*/container) {
     }
 
     const key = cleanText(children[0].textContent);
-    let value = cleanText(children[1].textContent);
+    const value = cleanText(children[1].textContent);
     // exceptions
     if (key.includes("Datensatz")) { // db link
       // https://d-nb.info/XXXXXXXXXXX
@@ -132,7 +132,7 @@ function extractTable(/**@type{HTMLTableElement}*/container) {
     }
     if (key === "Weiterführende Informationen" && value === "Inhaltstext") {  // description
       const descriptionLink = children[1].querySelector("a")?.href || null;
-      if (!!descriptionLink) {
+      if (descriptionLink) {
         table["descriptionLink"] = descriptionLink;
         continue;
       }
@@ -183,16 +183,13 @@ async function getDescription(bookDetails) {
 
   const url = new URL(link);
   url.protocol = "https:"; // have to be done
-  const res = await runtime.sendMessage({
-    action: 'fetchDepositData',
-    url: url.toString()
-  });
-  if (!res || res.status !== 'success') {
-    logMarian('Error from background script:', res && res.message);
+  const res = await fetchBackground(url.toString());
+  if (!res) {
+    logMarian('Error from background script: No response');
     return {}
   }
 
-  const text = extractTextFromHTML(res.data);
+  const text = extractTextFromHTML(res);
   return { "Description": text }
 }
 

--- a/src/extractors/googlebooks.js
+++ b/src/extractors/googlebooks.js
@@ -493,7 +493,7 @@ function getGoogleBookReadingFormat() {
 }
 
 function getContributors() {
-    const contribContainer = queryAllDeep(`div[role="presentation"] .PZPZlf`, KNOWN_HOSTS);
+    const contribContainer = queryAllDeep(`div[role="presentation"] .PZPZlf .zh0Yff`, KNOWN_HOSTS);
 
     const roles = ["Author", "Illustrator", "Translator", "Editor", "Contributor"]
     const roleLowers = roles.map(i => i.toLowerCase());

--- a/src/extractors/googlebooks.js
+++ b/src/extractors/googlebooks.js
@@ -1,6 +1,7 @@
 // googlebooks.js
+
+import { addContributor, cleanText, clearDeepQueryCache, collectObject, getCoverData, getFormattedText, logMarian, normalizeReadingFormat, queryAllDeep, queryDeep } from '../shared/utils.js';
 import { Extractor } from './AbstractExtractor.js';
-import { logMarian, getCoverData, cleanText, normalizeReadingFormat, collectObject, queryDeep, queryAllDeep, getFormattedText, addContributor, clearDeepQueryCache } from '../shared/utils.js';
 
 const KNOWN_HOSTS = ['g-expandable-content'];
 
@@ -22,9 +23,17 @@ class googleBooksScraper extends Extractor {
         // Extract cover image using volume ID
         const coverData = getCoverData(getGoogleBooksCoverUrl(sourceId));
 
-        const bookDetails = googlebooksClassic ?
-            getClassicGoogleBooksDetails() :
-            getGoogleBooksDetails();
+        let bookDetails = {};
+        if (sourceId) {
+            bookDetails = await fetchGoogleBooksApiDetails(sourceId);
+        }
+
+        if (Object.keys(bookDetails).length === 0) {
+            logMarian("Google Books API fallback: extracting from DOM.");
+            bookDetails = googlebooksClassic ?
+                getClassicGoogleBooksDetails() :
+                getGoogleBooksDetails();
+        }
 
         return collectObject([
             coverData,
@@ -32,6 +41,115 @@ class googleBooksScraper extends Extractor {
             mappings,
         ]);
     }
+}
+
+async function fetchGoogleBooksApiDetails(volumeId) {
+    try {
+        const response = await fetch(`https://www.googleapis.com/books/v1/volumes/${volumeId}`);
+        if (!response.ok) {
+            logMarian(`API responded with status ${response.status}`);
+            return {};
+        }
+        const data = await response.json();
+        return parseGoogleBooksApiData(data);
+    } catch (error) {
+        logMarian("Error fetching from Google Books API:", error);
+        return {};
+    }
+}
+
+function parseGoogleBooksApiData(data) {
+    const bookDetails = {};
+    const volumeInfo = data.volumeInfo || {};
+    const saleInfo = data.saleInfo || {};
+
+    // Title & Subtitle
+    let title = volumeInfo.title || "";
+    if (title && volumeInfo.subtitle) {
+        title = `${title}: ${volumeInfo.subtitle}`;
+    }
+    if (title) bookDetails["Title"] = cleanText(title);
+
+    // Description
+    if (volumeInfo.description) {
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = volumeInfo.description;
+        bookDetails["Description"] = getFormattedText(tempDiv);
+    }
+
+    // Identifiers (ISBNs)
+    if (volumeInfo.industryIdentifiers) {
+        for (const idObj of volumeInfo.industryIdentifiers) {
+            if (idObj.type === "ISBN_10") {
+                bookDetails["ISBN-10"] = idObj.identifier;
+            } else if (idObj.type === "ISBN_13") {
+                bookDetails["ISBN-13"] = idObj.identifier;
+            }
+        }
+    }
+
+    // Publication Date
+    if (volumeInfo.publishedDate) {
+        bookDetails["Publication date"] = volumeInfo.publishedDate;
+    }
+
+    // Publisher
+    if (volumeInfo.publisher) {
+        bookDetails["Publisher"] = cleanText(volumeInfo.publisher);
+    }
+
+    // Language
+    if (volumeInfo.language) {
+        bookDetails["Language"] = volumeInfo.language;
+    }
+
+    // Pages
+    if (volumeInfo.pageCount) {
+        bookDetails["Pages"] = volumeInfo.pageCount;
+    }
+
+    // Format
+    if (saleInfo.isEbook) {
+        bookDetails["Reading Format"] = "Ebook";
+        bookDetails["Edition Format"] = "Digital";
+    } else if (volumeInfo.printType === "BOOK") {
+        bookDetails["Reading Format"] = "Physical Book";
+        bookDetails["Edition Format"] = "Print";
+    } else if (volumeInfo.printType === "MAGAZINE") {
+        bookDetails["Reading Format"] = "Physical Book";
+        bookDetails["Edition Format"] = "Magazine";
+    }
+
+    // Contributors
+    const contributors = [];
+    if (volumeInfo.authors) {
+        for (const author of volumeInfo.authors) {
+            addContributor(contributors, cleanText(author), "Author");
+        }
+    }
+    if (contributors.length > 0) {
+        bookDetails["Contributors"] = contributors;
+    }
+
+    // Extra API Fields
+    if (volumeInfo.categories && volumeInfo.categories.length > 0) {
+        bookDetails["Categories"] = volumeInfo.categories;
+    }
+    if (volumeInfo.mainCategory) {
+        bookDetails["Main Category"] = volumeInfo.mainCategory;
+    }
+    if (volumeInfo.averageRating) {
+        bookDetails["Average Rating"] = volumeInfo.averageRating;
+    }
+    if (volumeInfo.ratingsCount) {
+        bookDetails["Ratings Count"] = volumeInfo.ratingsCount;
+    }
+    if (volumeInfo.maturityRating && volumeInfo.maturityRating !== "NOT_MATURE") {
+        bookDetails["Maturity Rating"] = volumeInfo.maturityRating;
+    }
+
+    logMarian("Google Books API extraction complete:", bookDetails);
+    return bookDetails;
 }
 
 function getGoogleBooksDetails() {
@@ -140,7 +258,7 @@ function getClassicGoogleBooksDetails() {
         bookDetails["Publication date"] = new Date(pubYearElement.children[1].textContent);
     }
 
-    let contributors = [];
+    const contributors = [];
     if ("Author" in bookInfo) {
         addContributor(contributors, cleanText(bookInfo["Author"].textContent), "Author");
         delete bookInfo["Author"];

--- a/src/extractors/googlebooks.js
+++ b/src/extractors/googlebooks.js
@@ -245,11 +245,11 @@ function getClassicGoogleBooksDetails() {
     }
 
     // assuming that its always in the format of "Publisher name, publication year"
-    const pubSplit = bookInfo["Publisher"].textContent.split(",");
-    // const pubYear = pubSplit[pubSplit.length - 1];
-    // bookDetails["Publication date"] = new Date(+pubYear, 0).toISOString();
-    bookDetails["Publisher"] = cleanText(pubSplit.slice(0, pubSplit.length - 1).join(","));
-    delete bookInfo["Publisher"];
+    const pubSplit = bookInfo["Publisher"]?.textContent?.split(",");
+    if (pubSplit) {
+        bookDetails["Publisher"] = cleanText(pubSplit.slice(0, pubSplit.length - 1).join(","));
+        delete bookInfo["Publisher"];
+    }
 
     const headerInfo = document.querySelectorAll("#bookinfo .bookinfo_sectionwrap div");
     const pubYearElement = Array.from(document.querySelectorAll("#bookinfo .bookinfo_sectionwrap div"))
@@ -268,6 +268,10 @@ function getClassicGoogleBooksDetails() {
             addContributor(contributors, cleanText(author.textContent), "Author")
         );
         delete bookInfo["Authors"];
+    }
+    if ("Illustrated by" in bookInfo) {
+        addContributor(contributors, cleanText(bookInfo["Illustrated by"].textContent), "Illustrator");
+        delete bookInfo["Author"];
     }
     bookDetails["Contributors"] = contributors;
 

--- a/src/extractors/inventaire.js
+++ b/src/extractors/inventaire.js
@@ -300,18 +300,10 @@ async function getInventaireDetails(id) {
   // Collect all details
   const result = await collectObject(detailsList);
 
-  // Merge contributors
-  let contributors = result["Contributors"] || [];
-  if (Array.isArray(result["Contributors"])) {
-    contributors = result["Contributors"];
-  }
-  delete result["Contributors"];
-  result["Contributors"] = contributors;
-
   // Merge mappings
   if (result["Mappings"]) {
     Object.entries(result["Mappings"]).forEach(([k, v]) => {
-      v.forEach(i => addMapping(mappings, k, i));
+      v.forEach(i => addMlpping(mappings, k, i));
     });
   }
   result["Mappings"] = mappings;

--- a/src/extractors/inventaire.js
+++ b/src/extractors/inventaire.js
@@ -303,7 +303,7 @@ async function getInventaireDetails(id) {
   // Merge mappings
   if (result["Mappings"]) {
     Object.entries(result["Mappings"]).forEach(([k, v]) => {
-      v.forEach(i => addMlpping(mappings, k, i));
+      v.forEach(i => addMapping(mappings, k, i));
     });
   }
   result["Mappings"] = mappings;

--- a/src/extractors/openlibrary.js
+++ b/src/extractors/openlibrary.js
@@ -49,14 +49,14 @@ async function getDetails(idUrl) {
   const mappings = {};
 
   if (isEdition) {
-    addMapping(mappings, "Open Liberary Edition", data["key"]);
+    addMapping(mappings, "Open Library Edition", data["key"]);
 
     const work = getFirstKey(data["works"]);
     if (work) {
       detailsList.push(getDetails(work));
     }
   } else {
-    addMapping(mappings, "Open Liberary Work", data["key"]);
+    addMapping(mappings, "Open Library Work", data["key"]);
   }
   if ("covers" in data) {
     const covers = data["covers"].filter((i) => i > 0);

--- a/src/manifest.base.json
+++ b/src/manifest.base.json
@@ -89,6 +89,16 @@
 
 		"https://api.audnex.us/*",
 		"https://api.audible.com/*",
+		"https://api.audible.co.uk/*",
+		"https://api.audible.ca/*",
+		"https://api.audible.com.au/*",
+		"https://api.audible.de/*",
+		"https://api.audible.fr/*",
+		"https://api.audible.it/*",
+		"https://api.audible.es/*",
+		"https://api.audible.co.jp/*",
+		"https://api.audible.in/*",
+		"https://api.audible.com.mx/*",
 		"https://www.googleapis.com/books/*",
 
 		"https://www.goodreads.com/*",

--- a/src/manifest.base.json
+++ b/src/manifest.base.json
@@ -87,6 +87,10 @@
 		"https://books.google.com.tr/books/*",
 		"https://books.google.ae/books/*",
 
+		"https://api.audnex.us/*",
+		"https://api.audible.com/*",
+		"https://www.googleapis.com/books/*",
+
 		"https://www.goodreads.com/*",
 		"https://app.thestorygraph.com/*",
 		"https://beta.thestorygraph.com/*",

--- a/src/popup/messaging.js
+++ b/src/popup/messaging.js
@@ -153,6 +153,10 @@ Please <a href="${issueUrl}" target="_blank" rel="noopener noreferrer">report</a
           reject('Failed to retrieve book details.');
           return;
         }
+        if (details.__marian_error) {
+          reject(details.__marian_error);
+          return;
+        }
         resolve(details);
       });
     }

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -422,6 +422,16 @@ async function getDetailsForTab(tab) {
     });
   } catch (err) {
     console.error("fetch details fail", err);
+    if (typeof err === 'string' && err.startsWith('MISSING_PERMISSION:')) {
+      const origin = err.split('MISSING_PERMISSION:')[1];
+      showStatus(`Permissions missing for ${origin}.<br/>
+<button 
+  id="permGrant" 
+  data-origin="${origin}"
+  data-tab-id="${tab.id}"
+>Grant Permissions</button>`);
+      return;
+    }
     showStatus("An issue occurred when fetching data");
     notifyBackground("REFRESH_ICON", { tab });
   }

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -292,7 +292,7 @@ export function addMapping(mappings, name, ids) {
     ids = [ids];
   }
 
-  let map = mappings[name] ?? [];
+  const map = mappings[name] ?? [];
   for (const id of ids) {
     if (!map.includes(id)) map.push(id);
   }
@@ -372,7 +372,7 @@ export async function collectObject(items) {
 
   const objList = await Promise.all(items);
 
-  let obj = {};
+  const obj = {};
   for (let i = 0; i < objList.length; i += 1) {
     const elm = objList[i];
     if (elm == undefined) {
@@ -408,6 +408,19 @@ export async function fetchHTML(url, args = undefined) {
   } catch (error) {
     console.error('Error fetching HTML:', error);
   }
+}
+
+/**
+ * Performs an HTTP request via the background script to bypass CSP restrictions.
+ * @param {string} url URL to fetch
+ * @returns {Promise<string>} response text
+ */
+export async function fetchBackground(url) {
+  const response = await runtime.sendMessage({ action: 'fetchUrl', url });
+  if (response && response.status === 'success') {
+    return response.data;
+  }
+  throw new Error(response?.message || 'Failed to fetch via background');
 }
 
 export { StorageBackedSet } from "./StorageSet.js";

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -375,12 +375,29 @@ export async function collectObject(items) {
   const obj = {};
   for (let i = 0; i < objList.length; i += 1) {
     const elm = objList[i];
-    if (elm == undefined) {
+    if (elm == null) {
       logMarian(`WARN: element number ${i} is ${elm}`)
       continue;
     }
-    Object.entries(elm)
-      .forEach(([k, v]) => obj[k] = v);
+    for (let [k, v] of Object.entries(elm)) {
+      // Merge contributors
+      if (k === "Contributors" && Array.isArray(v)) {
+        const contributors = obj["Contributors"] || [];
+        for (const item of v) {
+          if (item?.name) addContributor(contributors, item.name, item.roles || []);
+        }
+        v = contributors;
+      }
+
+      // Merge mappings
+      if (k === "Mappings") {
+        let mappings = obj["Mappings"] || {};
+        for (const [mapping, ids] of Object.entries(v)) mappings = addMapping(mappings, mapping, ids);
+        v = mappings;
+      }
+
+      obj[k] = v;
+    };
   }
 
   return obj;
@@ -420,14 +437,14 @@ export async function fetchBackground(url) {
   if (response && response.status === 'success') {
     return response.data;
   }
-  
+
   const msg = response?.message || '';
   if (msg.includes("NetworkError") || msg.includes("Failed to fetch") || msg.includes("CORS") || msg.includes("Missing Allow Origin")) {
-      const u = new URL(url);
-      const origin = `${u.protocol}//${u.host}/*`;
-      throw new Error(`MISSING_PERMISSION:${origin}`);
+    const u = new URL(url);
+    const origin = `${u.protocol}//${u.host}/*`;
+    throw new Error(`MISSING_PERMISSION:${origin}`);
   }
-  
+
   throw new Error(msg || 'Failed to fetch via background');
 }
 

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -420,7 +420,15 @@ export async function fetchBackground(url) {
   if (response && response.status === 'success') {
     return response.data;
   }
-  throw new Error(response?.message || 'Failed to fetch via background');
+  
+  const msg = response?.message || '';
+  if (msg.includes("NetworkError") || msg.includes("Failed to fetch") || msg.includes("CORS") || msg.includes("Missing Allow Origin")) {
+      const u = new URL(url);
+      const origin = `${u.protocol}//${u.host}/*`;
+      throw new Error(`MISSING_PERMISSION:${origin}`);
+  }
+  
+  throw new Error(msg || 'Failed to fetch via background');
 }
 
 export { StorageBackedSet } from "./StorageSet.js";


### PR DESCRIPTION
The Audible extractor will now use the Audible api as well as the Audnexus api to get the data instead of extracting the data from the apge
The Amazon extractor will also use the apis when extracting an audiobook to supplement the data scrapped data.

There is a rough attempt at having the Google books (and classic) extractor use the google books api, but there is a global shared daily limit, and someone is maxing it, so the api is unreliable unless we get our own key

relevant #28 - not a full implementation, but can be expanded upon in the future
fixes #87 
fixes #123 - Audiobooks will now have their length parts calculated from a `runtime_length_min` field, so text parsing issues shouldn't happen, but just in case I also now run the text through the `cleanText` function (as fallback)
fixes #127 - simplified the regex to not assume pd in the path, just look for an isbn10 or a ASIN in the path
fixes #131 - added some null checks to the regular google books parser and fixed the issue where it failed to get the correct element on contributors with no links