### PR TITLE
Add support for Hardcover audible mapping format

### DIFF
--- a/src/extractors/amazon.js
+++ b/src/extractors/amazon.js
@@ -88,9 +88,6 @@ class amazonScraper extends Extractor {
     if (audibleAsin &&
       (bookDetails["Reading Format"] === "Audiobook" || audibleDetails["Reading Format"] === "Audiobook")
     ) {
-      delete bookDetails["ASIN"];
-      bookDetails["Amazon ASIN"] = asin;
-      audibleDetails["ASIN"] = audibleAsin;
       apiPromise = fetchApiDetails(audibleAsin, audibleDetails);
     }
 

--- a/src/extractors/audible.js
+++ b/src/extractors/audible.js
@@ -29,7 +29,7 @@ class audibleScraper extends Extractor {
             return details;
         }
 
-        details.ASIN = asin;
+        // details.ASIN = asin;
 
         try {
             const audibleData = await fetchAudibleApiDetails(asin);
@@ -101,7 +101,8 @@ export async function fetchAudnexusApiDetails(asin, region = null) {
         region = getRegion(tld);
     }
 
-    details["Audible Region"] = region;
+    // details["Audible Region"] = region;
+    details["Mappings"] = { "Audible": [getHardcoverMapping(asin, region)] };
 
     let data;
 
@@ -193,7 +194,8 @@ export async function fetchAudibleApiDetails(asin, tld = null) {
     if (!tld.startsWith(".")) tld = `.${tld}`;
     const apiHost = `api.audible${tld}`;
 
-    details["Audible Region"] = getRegion(tld);
+    // details["Audible Region"] = getRegion(tld);
+    details["Mappings"] = { "Audible": [getHardcoverMapping(asin, getRegion(tld))] };
 
     try {
         resHtml = await fetchBackground(`https://${apiHost}/1.0/catalog/products/${asin}?response_groups=category_ladders,contributors,media,product_attrs,product_desc,product_details,product_extended_attrs,rating,series&image_sizes=512,1024`);
@@ -284,6 +286,18 @@ export async function fetchAudibleApiDetails(asin, tld = null) {
     // }
 
     return details;
+}
+
+
+/**
+ * Get the hardcover format for audible mappings of ASIN:region
+ *
+ * @param {string} asin The audible asin of the item
+ * @param {string} region The audible region for the ASIN
+ * @returns {string} The mapping string
+ */
+function getHardcoverMapping(asin, region) {
+    return `${asin.toUpperCase()}:${region.toLowerCase()}`
 }
 
 export { audibleScraper };


### PR DESCRIPTION
I added support for the new Hardcover format (coming soon:tm:) for audible asins, where they are a mapping with the region attached to the asin `ASIN:region` and the actual `ASIN` field is saved for amazon ASINs

<img width="1783" height="1082" alt="image" src="https://github.com/user-attachments/assets/6e5fb427-b33e-4cb9-8581-2318738ca247" />
<img width="1783" height="1082" alt="image" src="https://github.com/user-attachments/assets/3dcaf6f3-e44b-4874-9231-cbd12959d149" />

supersedes #136 