### PR TITLE
Get original release date from Goodreads

### DIFF
--- a/src/extractors/goodreads.js
+++ b/src/extractors/goodreads.js
@@ -85,6 +85,8 @@ function getBookDetails(apolloData, bookDetails) {
     if ("numPages" in details && details.numPages > 0) bookDetails["Pages"] = details.numPages;
   }
 
+  bookDetails['Original Publication date'] = getOriginalPublicationDate(apolloData, bookData);
+
   // series
   const bookSeries = bookData["bookSeries"];
   if (bookSeries && bookSeries.length > 0) {
@@ -122,6 +124,15 @@ function getContributor(apolloData, contributorObject) {
   const name = contributor.name;
 
   return { name, role }
+}
+
+function getOriginalPublicationDate(apolloData, bookData) {
+  const workRef = bookData?.work?.__ref;
+  if (!workRef) return null;
+
+  const workData = apolloData[workRef];
+  const publicationTime = workData?.details?.publicationTime;
+  return publicationTime ? new Date(publicationTime) : null;
 }
 
 export { goodreadsScraper };

--- a/src/popup/utils.js
+++ b/src/popup/utils.js
@@ -30,7 +30,8 @@ export const orderedKeys = [
   'Edition Information',
   'Publication date',
   'Language',
-  'Country'
+  'Country',
+  'Original Publication date',
 ];
 /**
  * Keys for all the elements that are used by hardcover
@@ -200,6 +201,10 @@ export function normalizeDetails(details, settings, inplace = true) {
   // format date
   if (details["Publication date"]) {
     details["Publication date"] = formatDate(details["Publication date"], settings.dateFormat);
+  }
+
+  if (details["Original Publication date"]) {
+    details["Original Publication date"] = formatDate(details["Original Publication date"], settings.dateFormat);
   }
 
   // Correct hyphenation on ISBNs according to settings


### PR DESCRIPTION
The Original release date is also available in the Next data, have it be fetched as well since hardcover now supports setting a separate date on books
<img width="1484" height="1220" alt="image" src="https://github.com/user-attachments/assets/fe9722d1-8158-4a16-a0b7-7e7ac54fb0d9" />

I had it sort to at the bottom of the info list